### PR TITLE
Add github actions workflows for plugin publishing

### DIFF
--- a/.github/workflows/patch.yml
+++ b/.github/workflows/patch.yml
@@ -1,0 +1,21 @@
+name: Publish Extension Patch
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the extension under $GITHUB_WORKSPACE.
+      - uses: actions/checkout@v2
+      # Install packages.
+      - name: Install packages
+        run: npm install
+      # Publish the extension.
+      - uses: lannonbr/vsce-action@2.0.0
+        with:
+          args: "publish patch -p $VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,21 @@
+name: Publish Extension Release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      # Check out the extension under $GITHUB_WORKSPACE.
+      - uses: actions/checkout@v2
+      # Install packages.
+      - name: Install packages
+        run: npm install
+      # Publish the extension.
+      - uses: lannonbr/vsce-action@2.0.0
+        with:
+          args: "publish $github.event.release.tag_name -p $VSCE_TOKEN"
+        env:
+          VSCE_TOKEN: ${{ secrets.VSCE_TOKEN }}


### PR DESCRIPTION
- [x] Workflow for publishing major releases, executed when a github release is created and published
- [x] Workflow for publishing patches, executed upon pushing / merging to master