### PR TITLE
Fix transformation loading upon daemon startup and memlet path highlighting

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "sdfv",
     "displayName": "DaCe SDFG Viewer (SDFV)",
     "description": "DaCe SDFG Viewer (SDFV) for VS Code",
-    "version": "0.2.13",
+    "version": "0.2.14",
     "engines": {
         "vscode": "^1.55.0"
     },

--- a/src/daceInterface.ts
+++ b/src/daceInterface.ts
@@ -535,7 +535,7 @@ implements MessageReceiverInterface {
 
         const callback = () => {
             TransformationHistoryProvider.getInstance()?.refresh();
-            TransformationListProvider.getInstance()?.refresh();
+            TransformationListProvider.getInstance()?.refresh(true);
         };
         if (vscode.workspace.getConfiguration(
                 'dace.interface'


### PR DESCRIPTION
- [x] Fix transformations not being loaded upon the initial booting of the DaCe daemon (Closes #22)
- [x] Fix memlet paths not highlighting (Closes #34)