### PR TITLE
Allow custom enum values to be shown in enum dropdowns

### DIFF
--- a/backend/run_dace.py
+++ b/backend/run_dace.py
@@ -526,9 +526,12 @@ def get_property_metdata():
                     # property is an enum), list those as metadata as well.
                     if inspect.isclass(prop.choices):
                         if issubclass(prop.choices, aenum.Enum):
-                            meta_dict[meta_key][propname]['choices'] = [
-                                str(e).split('.')[-1] for e in prop.choices
-                            ]
+                            choices = []
+                            for choice in prop.choices:
+                                choice_short = str(choice).split('.')[-1]
+                                if choice_short != 'Undefined':
+                                    choices.append(choice_short)
+                            meta_dict[meta_key][propname]['choices'] = choices
                 elif (propname == 'implementation'
                     and libnode_implementations is not None):
                     # For implementation properties, add all library

--- a/media/components/sdfv/vscode_sdfv.js
+++ b/media/components/sdfv/vscode_sdfv.js
@@ -194,6 +194,13 @@ function attr_table_put_select(
     const input = $('<select>', {
         'class': 'sdfv-property-dropdown',
     }).appendTo(cell);
+    if (!choices.includes(val))
+        input.append(new Option(
+            val,
+            val,
+            false,
+            true
+        ));
     choices.forEach(array => {
         input.append(new Option(
             array,


### PR DESCRIPTION
This closes #42.

While this does not yet allow for the _creation_ or editing of custom enum values, this allows custom enum values to be displayed without causing errors. This keeps all properties editable and allows the custom value to be selected.

At a later point, this should be handled via a combo-box, where custom values can be entered manually if so desired. This will be tackled and added at the end of [Phase 1](https://github.com/spcl/dace-vscode/projects/1) or in [Phase 2](https://github.com/spcl/dace-vscode/projects/2).

This change only removes error messages in combination with https://github.com/spcl/dace/pull/741.