### PR TITLE
Adds options to compile SDFGs and fixes bugs

### DIFF
--- a/media/resources/icons/dark/build.svg
+++ b/media/resources/icons/dark/build.svg
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   enable-background="new 0 0 1000 1000"
+   xml:space="preserve"
+   id="svg863"
+   sodipodi:docname="build.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)"><defs
+   id="defs867" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="3440"
+   inkscape:window-height="1377"
+   id="namedview865"
+   showgrid="false"
+   inkscape:zoom="0.42603184"
+   inkscape:cx="553.17896"
+   inkscape:cy="781.83383"
+   inkscape:window-x="1432"
+   inkscape:window-y="586"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg863" />
+<metadata
+   id="metadata851"> Svg Vector Icons : http://www.onlinewebfonts.com/icon <rdf:RDF><cc:Work
+     rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata>
+<path
+   d="m 204.1,392.2 c 19.7,0 39,-3.1 57.7,-9 L 372.6,493.9 493.9,372.6 383.1,261.8 c 21.3,-66.7 3.8,-140.6 -45.9,-190.3 -35.4,-35.5 -82.6,-55 -132.6,-55 -28,0 -56,6.3 -81.2,18.3 -3.8,1.8 -6.5,5.3 -7.2,9.5 -0.7,4.1 0.6,8.3 3.6,11.3 l 116.5,116.6 c 8.6,8.6 13.3,20 13.3,32.1 0,12.1 -4.8,23.5 -13.3,32.1 -17.1,17.2 -47.1,17.2 -64.2,0 L 55.6,119.9 c -3,-3 -7.3,-4.3 -11.3,-3.6 -4.1,0.7 -7.7,3.4 -9.5,7.2 -34.2,71.7 -19.5,157.6 36.6,213.7 35.5,35.5 82.6,55 132.7,55 z"
+   id="path853"
+   style="fill:#c5c5c5;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none" /><path
+   d="m 796,607.8 c -19.7,0 -39.1,3.1 -57.8,9.1 L 615.7,494.3 494.3,615.7 616.9,738.2 c -21.3,66.7 -3.8,140.6 45.9,190.3 35.4,35.4 82.6,54.9 132.6,54.9 28,0 56,-6.4 81.2,-18.3 3.8,-1.8 6.5,-5.3 7.2,-9.5 0.7,-4.2 -0.6,-8.3 -3.6,-11.3 L 763.6,827.7 c -8.6,-8.6 -13.3,-20 -13.3,-32.1 0,-12.1 4.7,-23.5 13.4,-32.1 17.2,-17.2 47,-17.2 64.2,0 L 944.5,880 c 3,3 7.1,4.3 11.3,3.6 4.1,-0.7 7.7,-3.4 9.5,-7.2 C 999.5,804.7 984.9,718.7 928.7,662.6 893.2,627.3 846.1,607.8 796,607.8 Z"
+   id="path855"
+   style="fill:#c5c5c5;fill-opacity:1;stroke:#000000;stroke-opacity:1;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none" /><path
+   d="m 746.1,331.5 c 0,0 20.3,17.8 37,9.5 18.9,-9.5 72.1,43 89.1,55.3 0.1,0 0.2,0 0.4,0.1 l -26.78278,29.98939 44.67406,39.90438 L 995.00789,353.99336 952.1527,314.35768 924.6,344.4 c -10.1,-14 -27,-37.8 -24.9,-45.7 9,-34.5 -61.5,-116.2 -61.5,-116.2 C 663.3,7.7 546.5,11.6 490.9,30.8 c -22.3,7.7 -18.2,12.5 5,16.6 168.6,29.4 189.5,128.9 161,167.2 -11,14.8 5,32.7 5,32.7 l 6,6 -647.51526,628.6913 c 20.21766,20.39558 61.249972,66.44082 81.96367,86.65815 L 734.9,320.3 Z"
+   id="path857"
+   sodipodi:nodetypes="cccccccccccccccccccc"
+   style="stroke:#000000;stroke-opacity:1;fill:#c5c5c5;fill-opacity:1;stroke-width:20;stroke-miterlimit:4;stroke-dasharray:none" />
+</svg>

--- a/media/resources/icons/light/build.svg
+++ b/media/resources/icons/light/build.svg
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   x="0px"
+   y="0px"
+   viewBox="0 0 1000 1000"
+   enable-background="new 0 0 1000 1000"
+   xml:space="preserve"
+   id="svg863"
+   sodipodi:docname="build.svg"
+   inkscape:version="1.0.2 (e86c870879, 2021-01-15, custom)"><defs
+   id="defs867" /><sodipodi:namedview
+   pagecolor="#ffffff"
+   bordercolor="#666666"
+   borderopacity="1"
+   objecttolerance="10"
+   gridtolerance="10"
+   guidetolerance="10"
+   inkscape:pageopacity="0"
+   inkscape:pageshadow="2"
+   inkscape:window-width="3440"
+   inkscape:window-height="1377"
+   id="namedview865"
+   showgrid="false"
+   inkscape:zoom="0.42603184"
+   inkscape:cx="668.2778"
+   inkscape:cy="431.03691"
+   inkscape:window-x="1432"
+   inkscape:window-y="586"
+   inkscape:window-maximized="1"
+   inkscape:current-layer="svg863" />
+<metadata
+   id="metadata851"> Svg Vector Icons : http://www.onlinewebfonts.com/icon <rdf:RDF><cc:Work
+     rdf:about=""><dc:format>image/svg+xml</dc:format><dc:type
+       rdf:resource="http://purl.org/dc/dcmitype/StillImage" /><dc:title></dc:title></cc:Work></rdf:RDF></metadata>
+<path
+   d="m 204.1,392.2 c 19.7,0 39,-3.1 57.7,-9 L 372.6,493.9 493.9,372.6 383.1,261.8 c 21.3,-66.7 3.8,-140.6 -45.9,-190.3 -35.4,-35.5 -82.6,-55 -132.6,-55 -28,0 -56,6.3 -81.2,18.3 -3.8,1.8 -6.5,5.3 -7.2,9.5 -0.7,4.1 0.6,8.3 3.6,11.3 l 116.5,116.6 c 8.6,8.6 13.3,20 13.3,32.1 0,12.1 -4.8,23.5 -13.3,32.1 -17.1,17.2 -47.1,17.2 -64.2,0 L 55.6,119.9 c -3,-3 -7.3,-4.3 -11.3,-3.6 -4.1,0.7 -7.7,3.4 -9.5,7.2 -34.2,71.7 -19.5,157.6 36.6,213.7 35.5,35.5 82.6,55 132.7,55 z"
+   id="path853" /><path
+   d="m 796,607.8 c -19.7,0 -39.1,3.1 -57.8,9.1 L 615.7,494.3 494.3,615.7 616.9,738.2 c -21.3,66.7 -3.8,140.6 45.9,190.3 35.4,35.4 82.6,54.9 132.6,54.9 28,0 56,-6.4 81.2,-18.3 3.8,-1.8 6.5,-5.3 7.2,-9.5 0.7,-4.2 -0.6,-8.3 -3.6,-11.3 L 763.6,827.7 c -8.6,-8.6 -13.3,-20 -13.3,-32.1 0,-12.1 4.7,-23.5 13.4,-32.1 17.2,-17.2 47,-17.2 64.2,0 L 944.5,880 c 3,3 7.1,4.3 11.3,3.6 4.1,-0.7 7.7,-3.4 9.5,-7.2 C 999.5,804.7 984.9,718.7 928.7,662.6 893.2,627.3 846.1,607.8 796,607.8 Z"
+   id="path855" /><path
+   d="m 746.1,331.5 c 0,0 20.3,17.8 37,9.5 18.9,-9.5 72.1,43 89.1,55.3 0.1,0 0.2,0 0.4,0.1 l -26.78278,29.98939 44.67406,39.90438 L 995.00789,353.99336 952.1527,314.35768 924.6,344.4 c -10.1,-14 -27,-37.8 -24.9,-45.7 9,-34.5 -61.5,-116.2 -61.5,-116.2 C 663.3,7.7 546.5,11.6 490.9,30.8 c -22.3,7.7 -18.2,12.5 5,16.6 168.6,29.4 189.5,128.9 161,167.2 -11,14.8 5,32.7 5,32.7 l 6,6 -647.51526,628.6913 c 20.21766,20.39558 61.249972,66.44082 81.96367,86.65815 L 734.9,320.3 Z"
+   id="path857"
+   sodipodi:nodetypes="cccccccccccccccccccc" />
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sdfv",
-    "version": "1.0.14",
+    "version": "1.0.15",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sdfv",
-            "version": "1.0.14",
+            "version": "1.0.15",
             "dependencies": {
                 "@popperjs/core": "^2.10.1",
                 "@spcl/sdfv": "^1.0.0",
@@ -255,9 +255,9 @@
             }
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.10",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
-            "integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
+            "version": "7.0.11",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
         "node_modules/@types/mathjs": {
@@ -310,9 +310,9 @@
             "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
         },
         "node_modules/@types/vscode": {
-            "version": "1.65.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-            "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+            "version": "1.66.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+            "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -1160,9 +1160,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001320",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
-            "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==",
+            "version": "1.0.30001325",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
+            "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
             "dev": true,
             "funding": [
                 {
@@ -1385,9 +1385,9 @@
             "dev": true
         },
         "node_modules/complex.js": {
-            "version": "2.0.15",
-            "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.15.tgz",
-            "integrity": "sha512-gDBvQU8IG139ZBQTSo2qvDFP+lANMGluM779csXOr6ny1NUtA3wkUnCFjlDNH/moAVfXtvClYt6G0zarFbtz5w==",
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.0.tgz",
+            "integrity": "sha512-RdcrDz7YynXp/YXGwXIZ4MtmxXXniT5WmLFRX93cuXUX+0geWAqB8l1BoLXF+3BkzviVzHlpw27P9ow7MvlcmA==",
             "engines": {
                 "node": "*"
             },
@@ -1680,9 +1680,9 @@
             }
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.92",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz",
-            "integrity": "sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA==",
+            "version": "1.4.103",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
+            "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
             "dev": true
         },
         "node_modules/emoji-regex": {
@@ -1773,9 +1773,9 @@
             }
         },
         "node_modules/es-abstract": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-            "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
+            "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
             "dev": true,
             "dependencies": {
                 "call-bind": "^1.0.2",
@@ -1784,15 +1784,15 @@
                 "get-intrinsic": "^1.1.1",
                 "get-symbol-description": "^1.0.0",
                 "has": "^1.0.3",
-                "has-symbols": "^1.0.2",
+                "has-symbols": "^1.0.3",
                 "internal-slot": "^1.0.3",
                 "is-callable": "^1.2.4",
-                "is-negative-zero": "^2.0.1",
+                "is-negative-zero": "^2.0.2",
                 "is-regex": "^1.1.4",
                 "is-shared-array-buffer": "^1.0.1",
                 "is-string": "^1.0.7",
-                "is-weakref": "^1.0.1",
-                "object-inspect": "^1.11.0",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.12.0",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.4",
@@ -3264,9 +3264,9 @@
             }
         },
         "node_modules/is-number-object": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-            "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
             "dev": true,
             "dependencies": {
                 "has-tostringtag": "^1.0.0"
@@ -3316,10 +3316,13 @@
             }
         },
         "node_modules/is-shared-array-buffer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-            "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
             "dev": true,
+            "dependencies": {
+                "call-bind": "^1.0.2"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -3714,12 +3717,12 @@
             "integrity": "sha512-CbtQXCmC9MXIIkz/0CmEfxELosxKxLegrjoa0mxM0zPA+GgAuhnWX6ITo/5oON/JFaCi/bh4MydEUNu0erbaxw=="
         },
         "node_modules/mathjs": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.4.1.tgz",
-            "integrity": "sha512-l/ONB3f2N9MMy/Gx3YPdKXjmV0LKN1Ew2fqcz3tzKlAIcPCFuLlup5KHm9cmKTKMHn7MVJZWegqCQhCDEpYyNQ==",
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.4.2.tgz",
+            "integrity": "sha512-3yXxFBR0V2Ij+jk7LV5k15lb+yivRxYRzjmuDYB1+yUzM3x7/XXNjIUZlcyp6l96BUMsOWzgZfIeYxg/dzqxKw==",
             "dependencies": {
                 "@babel/runtime": "^7.17.8",
-                "complex.js": "^2.0.15",
+                "complex.js": "^2.1.0",
                 "decimal.js": "^10.3.1",
                 "escape-latex": "^1.2.0",
                 "fraction.js": "^4.2.0",
@@ -3789,13 +3792,13 @@
             "dev": true
         },
         "node_modules/micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
             "dev": true,
             "dependencies": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
             },
             "engines": {
                 "node": ">=8.6"
@@ -4132,9 +4135,9 @@
             "dev": true
         },
         "node_modules/nanoid": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
+            "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
             "dev": true,
             "bin": {
                 "nanoid": "bin/nanoid.cjs"
@@ -4236,9 +4239,9 @@
             }
         },
         "node_modules/node-gyp/node_modules/gauge": {
-            "version": "4.0.3",
-            "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.3.tgz",
-            "integrity": "sha512-ICw1DhAwMtb22rYFwEHgJcx1JCwJGv3x6G0OQUq56Nge+H4Q8JEwr8iveS0XFlsUNSI67F5ffMGK25bK4Pmskw==",
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+            "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
             "dev": true,
             "dependencies": {
                 "aproba": "^1.0.3 || ^2.0.0",
@@ -4251,7 +4254,7 @@
                 "wide-align": "^1.1.5"
             },
             "engines": {
-                "node": "^12.13.0 || ^14.15.0 || >=16"
+                "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
             }
         },
         "node_modules/node-gyp/node_modules/npmlog": {
@@ -4995,9 +4998,9 @@
             }
         },
         "node_modules/postcss-selector-parser": {
-            "version": "6.0.9",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-            "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+            "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
             "dev": true,
             "dependencies": {
                 "cssesc": "^3.0.0",
@@ -6737,9 +6740,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.70.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
-            "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
+            "version": "5.71.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz",
+            "integrity": "sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
@@ -6922,9 +6925,9 @@
             }
         },
         "node_modules/wide-align/node_modules/ansi-regex": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+            "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
             "dev": true,
             "engines": {
                 "node": ">=4"
@@ -7305,9 +7308,9 @@
             }
         },
         "@types/json-schema": {
-            "version": "7.0.10",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.10.tgz",
-            "integrity": "sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==",
+            "version": "7.0.11",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.11.tgz",
+            "integrity": "sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==",
             "dev": true
         },
         "@types/mathjs": {
@@ -7360,9 +7363,9 @@
             "integrity": "sha512-JYM8x9EGF163bEyhdJBpR2QX1R5naCJHC8ucJylJ3w9/CVBaskdQ8WqBf8MmQrd1kRvp/a4TS8HJ+bxzR7ZJYQ=="
         },
         "@types/vscode": {
-            "version": "1.65.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.65.0.tgz",
-            "integrity": "sha512-wQhExnh2nEzpjDMSKhUvnNmz3ucpd3E+R7wJkOhBNK3No6fG3VUdmVmMOKD0A8NDZDDDiQcLNxe3oGmX5SjJ5w==",
+            "version": "1.66.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.66.0.tgz",
+            "integrity": "sha512-ZfJck4M7nrGasfs4A4YbUoxis3Vu24cETw3DERsNYtDZmYSYtk6ljKexKFKhImO/ZmY6ZMsmegu2FPkXoUFImA==",
             "dev": true
         },
         "@typescript-eslint/eslint-plugin": {
@@ -7991,9 +7994,9 @@
             }
         },
         "caniuse-lite": {
-            "version": "1.0.30001320",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001320.tgz",
-            "integrity": "sha512-MWPzG54AGdo3nWx7zHZTefseM5Y1ccM7hlQKHRqJkPozUaw3hNbBTMmLn16GG2FUzjR13Cr3NPfhIieX5PzXDA==",
+            "version": "1.0.30001325",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001325.tgz",
+            "integrity": "sha512-sB1bZHjseSjDtijV1Hb7PB2Zd58Kyx+n/9EotvZ4Qcz2K3d0lWB8dB4nb8wN/TsOGFq3UuAm0zQZNQ4SoR7TrQ==",
             "dev": true
         },
         "caseless": {
@@ -8167,9 +8170,9 @@
             "dev": true
         },
         "complex.js": {
-            "version": "2.0.15",
-            "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.0.15.tgz",
-            "integrity": "sha512-gDBvQU8IG139ZBQTSo2qvDFP+lANMGluM779csXOr6ny1NUtA3wkUnCFjlDNH/moAVfXtvClYt6G0zarFbtz5w=="
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/complex.js/-/complex.js-2.1.0.tgz",
+            "integrity": "sha512-RdcrDz7YynXp/YXGwXIZ4MtmxXXniT5WmLFRX93cuXUX+0geWAqB8l1BoLXF+3BkzviVzHlpw27P9ow7MvlcmA=="
         },
         "concat-map": {
             "version": "0.0.1",
@@ -8401,9 +8404,9 @@
             }
         },
         "electron-to-chromium": {
-            "version": "1.4.92",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.92.tgz",
-            "integrity": "sha512-YAVbvQIcDE/IJ/vzDMjD484/hsRbFPW2qXJPaYTfOhtligmfYEYOep+5QojpaEU9kq6bMvNeC2aG7arYvTHYsA==",
+            "version": "1.4.103",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.103.tgz",
+            "integrity": "sha512-c/uKWR1Z/W30Wy/sx3dkZoj4BijbXX85QKWu9jJfjho3LBAXNEGAEW3oWiGb+dotA6C6BzCTxL2/aLes7jlUeg==",
             "dev": true
         },
         "emoji-regex": {
@@ -8478,9 +8481,9 @@
             }
         },
         "es-abstract": {
-            "version": "1.19.1",
-            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.1.tgz",
-            "integrity": "sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==",
+            "version": "1.19.2",
+            "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.19.2.tgz",
+            "integrity": "sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==",
             "dev": true,
             "requires": {
                 "call-bind": "^1.0.2",
@@ -8489,15 +8492,15 @@
                 "get-intrinsic": "^1.1.1",
                 "get-symbol-description": "^1.0.0",
                 "has": "^1.0.3",
-                "has-symbols": "^1.0.2",
+                "has-symbols": "^1.0.3",
                 "internal-slot": "^1.0.3",
                 "is-callable": "^1.2.4",
-                "is-negative-zero": "^2.0.1",
+                "is-negative-zero": "^2.0.2",
                 "is-regex": "^1.1.4",
                 "is-shared-array-buffer": "^1.0.1",
                 "is-string": "^1.0.7",
-                "is-weakref": "^1.0.1",
-                "object-inspect": "^1.11.0",
+                "is-weakref": "^1.0.2",
+                "object-inspect": "^1.12.0",
                 "object-keys": "^1.1.1",
                 "object.assign": "^4.1.2",
                 "string.prototype.trimend": "^1.0.4",
@@ -9569,9 +9572,9 @@
             "dev": true
         },
         "is-number-object": {
-            "version": "1.0.6",
-            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.6.tgz",
-            "integrity": "sha512-bEVOqiRcvo3zO1+G2lVMy+gkkEm9Yh7cDMRusKKu5ZJKPUYSJwICTKZrNKHA2EbSP0Tu0+6B/emsYNHZyn6K8g==",
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/is-number-object/-/is-number-object-1.0.7.tgz",
+            "integrity": "sha512-k1U0IRzLMo7ZlYIfzRu23Oh6MiIFasgpb9X76eqfFZAqwH44UI4KTBvBYIZ1dSL9ZzChTB9ShHfLkR4pdW5krQ==",
             "dev": true,
             "requires": {
                 "has-tostringtag": "^1.0.0"
@@ -9603,10 +9606,13 @@
             }
         },
         "is-shared-array-buffer": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.1.tgz",
-            "integrity": "sha512-IU0NmyknYZN0rChcKhRO1X8LYz5Isj/Fsqh8NJOSf+N/hCOTwy29F32Ik7a+QszE63IdvmwdTPDd6cZ5pg4cwA==",
-            "dev": true
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-shared-array-buffer/-/is-shared-array-buffer-1.0.2.tgz",
+            "integrity": "sha512-sqN2UDu1/0y6uvXyStCOzyhAjCSlHceFoMKJW8W9EU9cvic/QdsZ0kEU93HEy3IUEFZIiH/3w+AH/UQbPHNdhA==",
+            "dev": true,
+            "requires": {
+                "call-bind": "^1.0.2"
+            }
         },
         "is-stream": {
             "version": "2.0.1",
@@ -9919,12 +9925,12 @@
             "integrity": "sha512-CbtQXCmC9MXIIkz/0CmEfxELosxKxLegrjoa0mxM0zPA+GgAuhnWX6ITo/5oON/JFaCi/bh4MydEUNu0erbaxw=="
         },
         "mathjs": {
-            "version": "10.4.1",
-            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.4.1.tgz",
-            "integrity": "sha512-l/ONB3f2N9MMy/Gx3YPdKXjmV0LKN1Ew2fqcz3tzKlAIcPCFuLlup5KHm9cmKTKMHn7MVJZWegqCQhCDEpYyNQ==",
+            "version": "10.4.2",
+            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-10.4.2.tgz",
+            "integrity": "sha512-3yXxFBR0V2Ij+jk7LV5k15lb+yivRxYRzjmuDYB1+yUzM3x7/XXNjIUZlcyp6l96BUMsOWzgZfIeYxg/dzqxKw==",
             "requires": {
                 "@babel/runtime": "^7.17.8",
-                "complex.js": "^2.0.15",
+                "complex.js": "^2.1.0",
                 "decimal.js": "^10.3.1",
                 "escape-latex": "^1.2.0",
                 "fraction.js": "^4.2.0",
@@ -9975,13 +9981,13 @@
             "dev": true
         },
         "micromatch": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
-            "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.5.tgz",
+            "integrity": "sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==",
             "dev": true,
             "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.2.3"
+                "braces": "^3.0.2",
+                "picomatch": "^2.3.1"
             }
         },
         "mime-db": {
@@ -10243,9 +10249,9 @@
             "dev": true
         },
         "nanoid": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
-            "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.2.tgz",
+            "integrity": "sha512-CuHBogktKwpm5g2sRgv83jEy2ijFzBwMoYA60orPDR7ynsLijJDqgsi4RDGj3OJpy3Ieb+LYwiRmIOGyytgITA==",
             "dev": true
         },
         "natural-compare": {
@@ -10325,9 +10331,9 @@
                     }
                 },
                 "gauge": {
-                    "version": "4.0.3",
-                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.3.tgz",
-                    "integrity": "sha512-ICw1DhAwMtb22rYFwEHgJcx1JCwJGv3x6G0OQUq56Nge+H4Q8JEwr8iveS0XFlsUNSI67F5ffMGK25bK4Pmskw==",
+                    "version": "4.0.4",
+                    "resolved": "https://registry.npmjs.org/gauge/-/gauge-4.0.4.tgz",
+                    "integrity": "sha512-f9m+BEN5jkg6a0fZjleidjN51VE1X+mPFQ2DJ0uv1V39oCLCbsGe6yjbBnp7eK7z/+GAon99a3nHuqbuuthyPg==",
                     "dev": true,
                     "requires": {
                         "aproba": "^1.0.3 || ^2.0.0",
@@ -10864,9 +10870,9 @@
             }
         },
         "postcss-selector-parser": {
-            "version": "6.0.9",
-            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.9.tgz",
-            "integrity": "sha512-UO3SgnZOVTwu4kyLR22UQ1xZh086RyNZppb7lLAKBFK8a32ttG5i87Y/P3+2bRSjZNyJ1B7hfFNo273tKe9YxQ==",
+            "version": "6.0.10",
+            "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+            "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
             "dev": true,
             "requires": {
                 "cssesc": "^3.0.0",
@@ -12191,9 +12197,9 @@
             }
         },
         "webpack": {
-            "version": "5.70.0",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.70.0.tgz",
-            "integrity": "sha512-ZMWWy8CeuTTjCxbeaQI21xSswseF2oNOwc70QSKNePvmxE7XW36i7vpBMYZFAUHPwQiEbNGCEYIOOlyRbdGmxw==",
+            "version": "5.71.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.71.0.tgz",
+            "integrity": "sha512-g4dFT7CFG8LY0iU5G8nBL6VlkT21Z7dcYDpJAEJV5Q1WLb9UwnFbrem1k7K52ILqEmomN7pnzWFxxE6SlDY56A==",
             "dev": true,
             "requires": {
                 "@types/eslint-scope": "^3.7.3",
@@ -12319,9 +12325,9 @@
             },
             "dependencies": {
                 "ansi-regex": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
-                    "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.1.tgz",
+                    "integrity": "sha512-+O9Jct8wf++lXxxFc4hc8LsjaSq0HFzzL7cVsw8pRDIPdjKD2mT4ytDZlLuSBZ4cLKZFXIrMGO7DbQCtMJJMKw==",
                     "dev": true
                 },
                 "is-fullwidth-code-point": {

--- a/package.json
+++ b/package.json
@@ -167,6 +167,11 @@
                             "Split the SDFG Optimizer layout horizontally",
                             "Split the SDFG Optimizer layout vertically"
                         ]
+                    },
+                    "dace.backend.interpreterPath": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Python interpreter path to use for the DaCe backend. Leave blank to use your default Python interpreter."
                     }
                 }
             }
@@ -322,6 +327,15 @@
                 "icon": "$(code)"
             },
             {
+                "command": "sdfg.compile",
+                "title": "Compile the SDFG file",
+                "category": "SDFV",
+                "icon": {
+                    "dark": "media/resources/icons/dark/build.svg",
+                    "light": "media/resources/icons/light/build.svg"
+                }
+            },
+            {
                 "command": "transformationList.sync",
                 "title": "Refresh Transformations",
                 "icon": {
@@ -464,6 +478,11 @@
                     "command": "sdfg.sourcefiles",
                     "when": "sdfg.showMenu.goto.py == true",
                     "group": "1_run@40"
+                },
+                {
+                    "command": "sdfg.compile",
+                    "group": "navigation@0",
+                    "when": "resourceLangId == sdfg"
                 }
             ],
             "editor/context": [

--- a/src/components/sdfg_viewer.ts
+++ b/src/components/sdfg_viewer.ts
@@ -323,7 +323,7 @@ export class SdfgViewerProvider
         startCol: number,
         endLine: number,
         endCol: number
-    ) {
+    ): void {
         /* Load the file and show it in a new editor, highlighting the
         indicated range. */
         vscode.workspace.openTextDocument(fileUri).then(
@@ -352,7 +352,7 @@ export class SdfgViewerProvider
         );
     }
 
-    public openViewer(uri: vscode.Uri, messages: Message[] = []) {
+    public openViewer(uri: vscode.Uri, messages: Message[] = []): void {
         // If the SDFG is currently open, then execute the messages
         // otherwise store them to execute as soon as the SDFG is loaded
         let editorIsLoaded = false;


### PR DESCRIPTION
Compile SDFGs:
- An option has been added to the SDFG editor's title bar, allowing
  SDFGs to be compiled. If the DaCe daemon hasn't been started yet,
  this attempts to start the daemon before compilation.

Bugfixes:
- Inability to start DaCe daemon, if the python extension does not
  contain proper environment setups, or if the user has multiple virtual
  environments, and their default does not support DaCe. An option now
  allows the user to override their default interpreter specifically for
  the DaCe backend.
- Auto-Open SDFGs has been fixed, and defaults to the .dacecache version
  now instead of the _dacegraphs version of the SDFG.