### PR TITLE
July Improvements 1/2

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 BSD 3-Clause License
 
-Copyright (c) 2020-2021, Scalable Parallel Computing Lab, ETH Zurich, and all contributors listed in AUTHORS
+Copyright (c) 2020-2022, Scalable Parallel Computing Lab, ETH Zurich, and all contributors listed in AUTHORS
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/backend/dace_vscode/arith_ops.py
+++ b/backend/dace_vscode/arith_ops.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+# Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 # All rights reserved.
 
 import ast

--- a/backend/dace_vscode/editing.py
+++ b/backend/dace_vscode/editing.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+# Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 # All rights reserved.
 
 from dace import (

--- a/backend/dace_vscode/transformations.py
+++ b/backend/dace_vscode/transformations.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+# Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 # All rights reserved.
 
 from dace import nodes, serialize

--- a/backend/dace_vscode/utils.py
+++ b/backend/dace_vscode/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+# Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 # All rights reserved.
 
 from dace import SDFG, SDFGState, nodes, serialize

--- a/backend/run_dace.py
+++ b/backend/run_dace.py
@@ -1,4 +1,4 @@
-# Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+# Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 # All rights reserved.
 
 #####################################################################

--- a/media/components/analysis/index.html
+++ b/media/components/analysis/index.html
@@ -184,11 +184,14 @@
                 </div>
                 <hr class="horizontal-divider">
                 <div id="symbol-list">
-                    <span>
+                    <span id="symbol-list-title">
                         Symbol list:
                     </span>
                     <table id="symbol-table">
                     </table>
+                    <div id="specialize-btn" class="btn btn-primary">
+                        Specialize SDFG
+                    </div>
                 </div>
             </div>
         </div>

--- a/media/components/analysis/index.html
+++ b/media/components/analysis/index.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors. -->
+<!-- Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors. -->
 <!-- All rights reserved. -->
 
 <!DOCTYPE html>

--- a/media/components/breakpoints/index.html
+++ b/media/components/breakpoints/index.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors. -->
+<!-- Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors. -->
 <!-- All rights reserved. -->
 
 <!DOCTYPE html>

--- a/media/components/history/index.html
+++ b/media/components/history/index.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors. -->
+<!-- Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors. -->
 <!-- All rights reserved. -->
 
 <!DOCTYPE html>

--- a/media/components/outline/index.html
+++ b/media/components/outline/index.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors. -->
+<!-- Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors. -->
 <!-- All rights reserved. -->
 
 <!DOCTYPE html>

--- a/media/components/sdfv/index.html
+++ b/media/components/sdfv/index.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors. -->
+<!-- Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors. -->
 <!-- All rights reserved. -->
 
 <!DOCTYPE html>

--- a/media/components/sdfv/index.html
+++ b/media/components/sdfv/index.html
@@ -13,6 +13,7 @@
         // Reference to the VSCode API.
         let vscode = undefined;
         const SPLIT_DIRECTION = 'vertical';
+        const MINIMAP_ENABLED = true;
     </script>
 
     <script src="{{ SCRIPT_SRC }}/pdfkit.standalone.js"></script>

--- a/media/components/transformations/index.html
+++ b/media/components/transformations/index.html
@@ -1,4 +1,4 @@
-<!-- Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors. -->
+<!-- Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors. -->
 <!-- All rights reserved. -->
 
 <!DOCTYPE html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sdfv",
-    "version": "1.1.3",
+    "version": "1.3.0",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "sdfv",
-            "version": "1.1.3",
+            "version": "1.3.0",
             "dependencies": {
                 "@popperjs/core": "^2.10.1",
                 "@spcl/sdfv": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,15 @@
     "extensionDependencies": [
         "benjamin-simmonds.pythoncpp-debug"
     ],
+    "capabilities": {
+        "untrustedWorkspaces": {
+            "supported": "limited",
+            "restrictedConfigurations": [
+                "dace.backend.interpreterPath"
+            ],
+            "description": "Certain functionality, like executing or transforming SDFGs, might be unavailable in untrusted workspaces to keep you safe."
+        }
+    },
     "contributes": {
         "debuggers": [
             {
@@ -492,7 +501,7 @@
                 {
                     "command": "sdfg.compile",
                     "group": "navigation@0",
-                    "when": "resourceLangId == sdfg"
+                    "when": "resourceLangId == sdfg && isWorkspaceTrusted"
                 }
             ],
             "editor/context": [
@@ -520,12 +529,12 @@
             "view/title": [
                 {
                     "command": "transformationList.addCustom",
-                    "when": "view == transformationList",
+                    "when": "view == transformationList && isWorkspaceTrusted",
                     "group": "navigation"
                 },
                 {
                     "command": "transformationList.addCustomFromDir",
-                    "when": "view == transformationList",
+                    "when": "view == transformationList && isWorkspaceTrusted",
                     "group": "navigation"
                 },
                 {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "sdfv",
     "displayName": "DaCe SDFG Editor",
     "description": "Transform and optimize data-centric programs with a click of a button",
-    "version": "1.1.3",
+    "version": "1.3.0",
     "engines": {
         "vscode": "^1.68.0"
     },

--- a/package.json
+++ b/package.json
@@ -177,6 +177,11 @@
                             "Split the SDFG Optimizer layout vertically"
                         ]
                     },
+                    "dace.sdfv.minimap": {
+                        "type": "boolean",
+                        "default": true,
+                        "description": "Show a minimap in the top right corner of the SDFG editor"
+                    },
                     "dace.backend.interpreterPath": {
                         "type": "string",
                         "default": "",

--- a/src/components/analysis.ts
+++ b/src/components/analysis.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as path from 'path';

--- a/src/components/base_component.ts
+++ b/src/components/base_component.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as vscode from 'vscode';

--- a/src/components/messaging/component_message_handler.ts
+++ b/src/components/messaging/component_message_handler.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as vscode from 'vscode';

--- a/src/components/messaging/message_receiver_interface.ts
+++ b/src/components/messaging/message_receiver_interface.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as vscode from 'vscode';

--- a/src/components/optimization_panel.ts
+++ b/src/components/optimization_panel.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import { AnalysisProvider } from './analysis';

--- a/src/components/outline.ts
+++ b/src/components/outline.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as path from 'path';

--- a/src/components/sdfg_breakpoints.ts
+++ b/src/components/sdfg_breakpoints.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as path from 'path';

--- a/src/components/sdfg_viewer.ts
+++ b/src/components/sdfg_viewer.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as path from 'path';

--- a/src/components/sdfg_viewer.ts
+++ b/src/components/sdfg_viewer.ts
@@ -505,11 +505,10 @@ export class SdfgViewerProvider
         );
 
         // If the settings indicate it, split the webview vertically and put
-        // the info container to the right instead of at the bottom.
-        if (vscode.workspace.getConfiguration(
-            'dace.sdfv'
-        ).layout === 'vertical'
-        ) {
+        // the info container to the right instead of at the bottom. Also hide
+        // the minimap if the settings say so.
+        const sdfvConfig = vscode.workspace.getConfiguration('dace.sdfv');
+        if (sdfvConfig?.get<string>('layout') === 'vertical') {
             baseHtml = baseHtml.replace(
                 '<div id="split-container" class="split-container-vertical">',
                 '<div id="split-container" style="display: flex;" class="split-container-horizontal">'
@@ -519,6 +518,11 @@ export class SdfgViewerProvider
                 'SPLIT_DIRECTION = \'horizontal\';'
             );
         }
+        if (sdfvConfig?.get<boolean>('minimap') === false)
+            baseHtml = baseHtml.replace(
+                'MINIMAP_ENABLED = true;',
+                'MINIMAP_ENABLED = false;'
+            );
 
         return baseHtml;
     }

--- a/src/components/transformation_history.ts
+++ b/src/components/transformation_history.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as path from 'path';

--- a/src/components/transformation_list.ts
+++ b/src/components/transformation_list.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as path from 'path';

--- a/src/dace_interface.ts
+++ b/src/dace_interface.ts
@@ -81,6 +81,16 @@ export class DaCeInterface
             case 'query_sdfg_metadata':
                 this.querySdfgMetadata();
                 break;
+            case 'specialize_graph':
+                if (message.symbolMap !== undefined) {
+                    const sdfgFile =
+                        DaCeVSCode.getInstance().getActiveSdfgFileName();
+                    if (sdfgFile) {
+                        const uri = vscode.Uri.file(sdfgFile);
+                        this.specializeGraph(uri, message.symbolMap);
+                    }
+                }
+                break;
             default:
                 break;
         }
@@ -761,6 +771,23 @@ export class DaCeInterface
             callback,
             undefined,
             true
+        );
+    }
+
+    public specializeGraph(
+        uri: vscode.Uri, symbolMap: { [symbol: string]: any | undefined }
+    ): void {
+        this.showSpinner('Specializing');
+        this.sendPostRequest(
+            '/specialize_sdfg',
+            {
+                'path': uri.fsPath,
+                'symbol_map': symbolMap,
+            },
+            (data: any) => {
+                this.hideSpinner();
+                this.writeToActiveDocument(data.sdfg);
+            }
         );
     }
 

--- a/src/dace_interface.ts
+++ b/src/dace_interface.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as os from 'os';

--- a/src/debugger/breakpoint_handler.ts
+++ b/src/debugger/breakpoint_handler.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as path from 'path';

--- a/src/debugger/dace_debugger.ts
+++ b/src/debugger/dace_debugger.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as vscode from 'vscode';

--- a/src/debugger/dace_debugging_session.ts
+++ b/src/debugger/dace_debugging_session.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import { LoggingDebugSession, TerminatedEvent } from 'vscode-debugadapter';

--- a/src/debugger/dace_listener.ts
+++ b/src/debugger/dace_listener.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import {

--- a/src/debugger/sdfg_python_debug_session.ts
+++ b/src/debugger/sdfg_python_debug_session.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import {

--- a/src/debugger/sdfg_python_debugger.ts
+++ b/src/debugger/sdfg_python_debugger.ts
@@ -1,7 +1,8 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as vscode from 'vscode';
+import { executeTrusted } from '../utils/utils';
 import { SdfgPythonDebugSession } from './sdfg_python_debug_session';
 import { FileAccessor } from './sdfg_python_runtime';
 
@@ -10,32 +11,36 @@ export function activateSdfgPython(context: vscode.ExtensionContext) {
         vscode.commands.registerCommand(
             'sdfg.debug.run',
             (resource: vscode.Uri) => {
-                if (resource) {
-                    vscode.debug.startDebugging(undefined, {
-                        type: 'sdfg-python',
-                        name: 'Run current SDFG',
-                        request: 'launch',
-                        program: resource.fsPath,
-                    }, {
-                        noDebug: true,
-                    });
-                }
+                executeTrusted(() => {
+                    if (resource) {
+                        vscode.debug.startDebugging(undefined, {
+                            type: 'sdfg-python',
+                            name: 'Run current SDFG',
+                            request: 'launch',
+                            program: resource.fsPath,
+                        }, {
+                            noDebug: true,
+                        });
+                    }
+                }, false, 'Execution of SDFGs');
             }
         ),
         vscode.commands.registerCommand(
             'sdfg.debug.profile',
             (resource: vscode.Uri) => {
-                if (resource) {
-                    vscode.debug.startDebugging(undefined, {
-                        type: 'sdfg-python',
-                        name: 'Profile current SDFG',
-                        request: 'launch',
-                        profile: true,
-                        program: resource.fsPath,
-                    }, {
-                        noDebug: true,
-                    });
-                }
+                executeTrusted(() => {
+                    if (resource) {
+                        vscode.debug.startDebugging(undefined, {
+                            type: 'sdfg-python',
+                            name: 'Profile current SDFG',
+                            request: 'launch',
+                            profile: true,
+                            program: resource.fsPath,
+                        }, {
+                            noDebug: true,
+                        });
+                    }
+                }, false, 'Profiling of SDFGs');
             }
         )
     );

--- a/src/debugger/sdfg_python_runtime.ts
+++ b/src/debugger/sdfg_python_runtime.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as vscode from 'vscode';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as vscode from 'vscode';
@@ -16,6 +16,7 @@ import { TransformationListProvider } from './components/transformation_list';
 import { SdfgBreakpointProvider } from './components/sdfg_breakpoints';
 import { activateSdfgPython } from './debugger/sdfg_python_debugger';
 import { activateDaceDebug } from './debugger/dace_debugger';
+import { executeTrusted } from './utils/utils';
 
 export class DaCeVSCode {
 
@@ -261,10 +262,14 @@ export class DaCeVSCode {
             }
         });
         this.registerCommand('transformationList.addCustom', () => {
-            DaCeInterface.getInstance().addCustomTransformations(false);
+            executeTrusted(() => {
+                DaCeInterface.getInstance().addCustomTransformations(false);
+            }, false , 'Loading custom transformations');
         });
         this.registerCommand('transformationList.addCustomFromDir', () => {
-            DaCeInterface.getInstance().addCustomTransformations(true);
+            executeTrusted(() => {
+                DaCeInterface.getInstance().addCustomTransformations(true);
+            }, false , 'Loading custom transformations');
         });
         this.registerCommand('transformationList.sync', () => {
             DaCeVSCode.getInstance().getActiveEditor()?.postMessage({
@@ -316,7 +321,7 @@ export class DaCeVSCode {
             const uri = vscode.Uri.file(
                 join(homedir(), '.dace.conf')
             );
-            vscode.commands.executeCommand("vscode.openWith", uri, "default");
+            vscode.commands.executeCommand('vscode.openWith', uri, 'default');
         });
 
         const sdfgWatcher = vscode.workspace.createFileSystemWatcher(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -308,20 +308,24 @@ export class DaCeVSCode {
             (h) => DaCeInterface.getInstance().previewHistoryPoint(h));
         this.registerCommand('sdfg.applyHistoryPoint',
             (h) => DaCeInterface.getInstance().applyHistoryPoint(h));
-        this.registerCommand('dace.openOptimizerInTerminal',
-            () => DaCeInterface.getInstance().startDaemonInTerminal());
         this.registerCommand('dace.installDace', () => {
-            const term = vscode.window.createTerminal('Install DaCe');
-            term.show();
-            term.sendText(
-                'pip install dace'
-            );
+            executeTrusted(() => {
+                const term = vscode.window.createTerminal('Install DaCe');
+                term.show();
+                term.sendText(
+                    'pip install dace'
+                );
+            }, false, 'Installing DaCe');
         });
         this.registerCommand('dace.config', () => {
-            const uri = vscode.Uri.file(
-                join(homedir(), '.dace.conf')
-            );
-            vscode.commands.executeCommand('vscode.openWith', uri, 'default');
+            executeTrusted(() => {
+                const uri = vscode.Uri.file(
+                    join(homedir(), '.dace.conf')
+                );
+                vscode.commands.executeCommand(
+                    'vscode.openWith', uri, 'default'
+                );
+            }, false, 'Accessing the user\'s dace.config');
         });
 
         const sdfgWatcher = vscode.workspace.createFileSystemWatcher(

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 export type Range = {

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as vscode from 'vscode';
@@ -19,4 +19,37 @@ export async function* walkDirectory(
             }
         }
     }
+}
+
+export function showUntrustedWorkspaceWarning(
+    customFeatureMsg?: string, callback?: (e: void) => any
+): void {
+    const trustWorkspaceMsg = 'Trust this workspace';
+    vscode.window.showErrorMessage(
+        (customFeatureMsg ? customFeatureMsg : 'This feature') +
+        ' is disabled in untrusted workspaces to keep you safe. ' +
+        'If you trust the workspace, you can disable restricted mode to use ' +
+        'this feature.',
+        trustWorkspaceMsg
+    ).then((val) => {
+        if (val === trustWorkspaceMsg)
+            vscode.env.openExternal(vscode.Uri.parse(
+                'https://code.visualstudio.com/docs/editor/workspace-trust' +
+                '#_trusting-a-workspace'
+            ));
+    });
+
+    if (callback !== undefined)
+        vscode.workspace.onDidGrantWorkspaceTrust(callback);
+}
+
+export function executeTrusted(
+    f: (e: void) => any, runOnTrusted: boolean = false, customMessage?: string
+): void {
+    if (vscode.workspace.isTrusted)
+        f();
+    else
+        showUntrustedWorkspaceWarning(
+            customMessage, runOnTrusted ? f : undefined
+        );
 }

--- a/src/webclients/components/analysis/analysis.css
+++ b/src/webclients/components/analysis/analysis.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+/* Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
  * All rights reserved. */
 
 html {

--- a/src/webclients/components/analysis/analysis.css
+++ b/src/webclients/components/analysis/analysis.css
@@ -64,8 +64,13 @@ body {
     margin-right: .3rem;
 }
 
+#symbol-list {
+    padding-bottom: .5rem;
+}
+
 #symbol-table {
     width: 100%;
+    margin: .5rem 0;
 }
 
 #symbol-table .symbol-entry .symbol {

--- a/src/webclients/components/analysis/analysis.ts
+++ b/src/webclients/components/analysis/analysis.ts
@@ -143,6 +143,13 @@ class SymbolResolution {
         });
     }
 
+    public specializeGraph(): void {
+        vscode.postMessage({
+            type: 'dace.specialize_graph',
+            symbolMap: this.symbols,
+        });
+    }
+
 }
 
 function clearRuntimeReport() {
@@ -370,7 +377,7 @@ $(() => {
             fr.readAsText(that.files[0]);
     });
 
-    $('#runtime-time-criterium-select').change(() => {
+    $('#runtime-time-criterium-select').on('change', () => {
         if (vscode)
             vscode.postMessage({
                 type: 'sdfv.instrumentation_report_change_criterium',
@@ -384,6 +391,10 @@ $(() => {
 
     $('#runtime-report-browse-btn').on('click', () => {
         $('#runtime-report-file-input').trigger('click');
+    });
+
+    $('#specialize-btn').on('click', () => {
+        symbolResolution?.specializeGraph();
     });
 
     if (vscode)

--- a/src/webclients/components/analysis/analysis.ts
+++ b/src/webclients/components/analysis/analysis.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as $ from 'jquery';

--- a/src/webclients/components/breakpoints/breakpoints.css
+++ b/src/webclients/components/breakpoints/breakpoints.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+/* Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
  * All rights reserved. */
 
 html {

--- a/src/webclients/components/breakpoints/breakpoints.ts
+++ b/src/webclients/components/breakpoints/breakpoints.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as $ from 'jquery';

--- a/src/webclients/components/history/transformation_history.css
+++ b/src/webclients/components/history/transformation_history.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+/* Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
  * All rights reserved. */
 
 html {

--- a/src/webclients/components/history/transformation_history.ts
+++ b/src/webclients/components/history/transformation_history.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as $ from 'jquery';

--- a/src/webclients/components/outline/outline.css
+++ b/src/webclients/components/outline/outline.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+/* Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
  * All rights reserved. */
 
 html {

--- a/src/webclients/components/outline/outline.ts
+++ b/src/webclients/components/outline/outline.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import 'bootstrap';

--- a/src/webclients/components/sdfv/analysis/analysis.ts
+++ b/src/webclients/components/sdfv/analysis/analysis.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import {

--- a/src/webclients/components/sdfv/breakpoints/breakpoints.ts
+++ b/src/webclients/components/sdfv/breakpoints/breakpoints.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import {

--- a/src/webclients/components/sdfv/messaging/message_handler.ts
+++ b/src/webclients/components/sdfv/messaging/message_handler.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import {

--- a/src/webclients/components/sdfv/properties/properties.ts
+++ b/src/webclients/components/sdfv/properties/properties.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import { string_to_sdfg_typeclass } from '@spcl/sdfv/out';

--- a/src/webclients/components/sdfv/properties/properties.ts
+++ b/src/webclients/components/sdfv/properties/properties.ts
@@ -287,7 +287,7 @@ export class TypeclassProperty extends ComboboxProperty {
             backgroundInput
         );
 
-        if (typeof target[key] === 'object') {
+        if (target[key] && typeof target[key] === 'object') {
             editCompoundButton.show();
             this.compoundValueType = target[key]['type'];
             this.compoundValues = target[key];

--- a/src/webclients/components/sdfv/renderer/vscode_renderer.ts
+++ b/src/webclients/components/sdfv/renderer/vscode_renderer.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import {

--- a/src/webclients/components/sdfv/transformation/transformation.ts
+++ b/src/webclients/components/sdfv/transformation/transformation.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import { JsonTransformation } from '../../transformations/transformations';

--- a/src/webclients/components/sdfv/utils/attributes_table.ts
+++ b/src/webclients/components/sdfv/utils/attributes_table.ts
@@ -923,7 +923,15 @@ export function attributeTablePutEntry(
         'class': 'col-9 attr-table-cell',
     }).appendTo(row);
 
-    if (dtype === undefined) {
+    if (key === 'constants_prop') {
+        const constContainer = $('<div>').appendTo(valueCell);
+        for (const k in val) {
+            const v = val[k];
+            constContainer.append($('<div>', {
+                text: k + ': ' + v[1].toString(),
+            }));
+        }
+    } else if (dtype === undefined) {
         // Implementations that are set to null should still be visible. Other
         // null properties should be shown as an empty field.
         if (key === 'implementation' && val === null)

--- a/src/webclients/components/sdfv/utils/attributes_table.ts
+++ b/src/webclients/components/sdfv/utils/attributes_table.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import {

--- a/src/webclients/components/sdfv/utils/attributes_table.ts
+++ b/src/webclients/components/sdfv/utils/attributes_table.ts
@@ -330,7 +330,7 @@ export function attrTablePutTypeclass(
     }).appendTo(cell);
     const choices = baseTypes.concat(Object.keys(compoundTypes));
 
-    const typeval = typeof val === 'object' ? val['type'] : val;
+    const typeval = val ? (typeof val === 'object' ? val['type'] : val) : null;
     let found = false;
     if (choices) {
         choices.forEach(array => {
@@ -346,7 +346,7 @@ export function attrTablePutTypeclass(
         });
     }
 
-    if (!found)
+    if (!found && typeval)
         input.append(new Option(typeval, typeval, true, true));
 
     input.editableSelect({

--- a/src/webclients/components/sdfv/utils/attributes_table.ts
+++ b/src/webclients/components/sdfv/utils/attributes_table.ts
@@ -121,20 +121,21 @@ export function attrTablePutCode(
 
     const editor = monaco_editor.create(
         input.get(0)!, {
-            'value': val,
-            'language': lang === undefined ? 'python' : lang.toLowerCase(),
-            'theme': getMonacoThemeName(),
-            'glyphMargin': false,
-            'lineDecorationsWidth': 0,
-            'lineNumbers': 'off',
-            'lineNumbersMinChars': 0,
-            'minimap': {
-                'enabled': false,
+            value: val,
+            language: lang === undefined ? 'python' : lang.toLowerCase(),
+            theme: getMonacoThemeName(),
+            glyphMargin: false,
+            lineDecorationsWidth: 0,
+            lineNumbers: 'off',
+            lineNumbersMinChars: 0,
+            minimap: {
+                enabled: false,
             },
-            'padding': {
-                'top': 0,
-                'bottom': 0,
+            padding: {
+                top: 0,
+                bottom: 0,
             },
+            automaticLayout: true,
         }
     );
 

--- a/src/webclients/components/sdfv/utils/helpers.ts
+++ b/src/webclients/components/sdfv/utils/helpers.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import {

--- a/src/webclients/components/sdfv/vscode_sdfv.css
+++ b/src/webclients/components/sdfv/vscode_sdfv.css
@@ -501,6 +501,7 @@ pre.code {
   flex-direction: row;
   align-items: center;
   justify-content: left;
+  flex-basis: auto;
   width: 100%;
 }
 
@@ -508,6 +509,7 @@ pre.code {
   flex-grow: 1;
   height: 6rem;
   margin-right: .8rem;
+  min-width: 0;
   border: 1px solid;
   border-bottom: 1px solid;
   border-color: var(--vscode-input-border);

--- a/src/webclients/components/sdfv/vscode_sdfv.css
+++ b/src/webclients/components/sdfv/vscode_sdfv.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+/* Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
  * All rights reserved. */
 
 body {

--- a/src/webclients/components/sdfv/vscode_sdfv.ts
+++ b/src/webclients/components/sdfv/vscode_sdfv.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as $ from 'jquery';

--- a/src/webclients/components/transformations/transformations.css
+++ b/src/webclients/components/transformations/transformations.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+/* Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
  * All rights reserved. */
 
 html {

--- a/src/webclients/components/transformations/transformations.ts
+++ b/src/webclients/components/transformations/transformations.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 import * as $ from 'jquery';

--- a/src/webclients/elements/treeview/treeview.css
+++ b/src/webclients/elements/treeview/treeview.css
@@ -1,4 +1,4 @@
-/* Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+/* Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
  * All rights reserved. */
 
 .tree-view-list {

--- a/src/webclients/elements/treeview/treeview.ts
+++ b/src/webclients/elements/treeview/treeview.ts
@@ -1,4 +1,4 @@
-// Copyright 2020-2021 ETH Zurich and the DaCe-VSCode authors.
+// Copyright 2020-2022 ETH Zurich and the DaCe-VSCode authors.
 // All rights reserved.
 
 export class CustomTreeViewItem {


### PR DESCRIPTION
- [x] Fix a bug with metadata parsing, that makes it impossible to edit dictionary properties that contain typeclasses. Closes #171.
- [x] Support workspace trust. Closes #47. We provide limited support for untrusted workspaces by disabling certain features in restricted mode. Execution, compilation, debugging etc. of SDFGs is disabled, as well as loading of custom transformations. The DaCe daemon itself can be run because it doesn't execute arbitrary code and all code is provided by the extension.
- [x] Allow SDFGs to be specialized through the UI (Closes #45)
- [x] Make the minimap toggleable via config (Closes #177) Available as soon as https://github.com/spcl/dace-webclient/pull/82 is merged in.
- [x] Update copyright information. 
- [x] Dynamically resize code editors (Closes #160)

## Note on releasing:
This will be released in _preview_ mode as version 1.3.0. The next tick (July improvements 2/2) will then be released towards the end of the month as 1.3.1 (again, preview), while this patch will be pulled into **release** with version 1.2.0.
From this point on, all _even_ minor versions are _release_ versions (1.0.x, 1.2.x, 1.4.x, etc.), while all odd minor versions are _preview_ mode releases (1.1.x, 1.3.x, etc.). This follows microsoft's [recommendations for pre-release extensions](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#prerelease-extensions) until their system supports `semver` version tagging.