### PR TITLE
Ensuring Daemon Editor are connected through Ipv6

### DIFF
--- a/backend/run_dace.py
+++ b/backend/run_dace.py
@@ -432,7 +432,7 @@ def run_daemon(port):
     def _get_metadata():
         return get_property_metadata()
 
-    daemon.run(port=port)
+    daemon.run(host='::1', port=port)
 
 
 if __name__ == '__main__':

--- a/src/components/dace_interface.ts
+++ b/src/components/dace_interface.ts
@@ -270,7 +270,7 @@ implements vscode.WebviewViewProvider {
         const connectionIntervalId = setInterval(() => {
             console.log('Checking for daemon');
             const req = request({
-                host: 'localhost',
+                host: '::1',
                 port: this.port,
                 path: '/',
                 method: 'GET',
@@ -338,7 +338,7 @@ implements vscode.WebviewViewProvider {
                 method = 'POST';
 
             let parameters = {
-                host: 'localhost',
+                host: '::1',
                 port: this.port,
                 path: url,
                 method: method,


### PR DESCRIPTION
On my machine (Manjaro) the connection between the daemon and the editor did not work.
After some time I figured out that the daemon was listening on `127.0.0.1`, while the editor was trying to connect to `::1`, which did not work.

This PR fixes this by explicitly use `::1` for communication.