### PR TITLE
Prepare for release (1.6.0 and 1.7.0-insider)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "sdfv",
-    "version": "1.5.6",
+    "version": "1.7.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "sdfv",
-            "version": "1.5.6",
+            "version": "1.7.0",
             "hasInstallScript": true,
             "workspaces": [
                 "./packages/sdfv"
@@ -144,18 +144,18 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.22.20.tgz",
-            "integrity": "sha512-BQYjKbpXjoXwFW5jGqiizJQQT/aC7pFm9Ok1OWssonuguICi264lbgMzRp2ZMmRSlfkX6DsWDDcsrctK8Rwfiw==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.23.2.tgz",
+            "integrity": "sha512-0S9TQMmDHlqAZ2ITT95irXKfxN9bncq8ZCoJhun3nHL/lLUxd2NKBJYoNGWH7S0hz6fRQwWlAWn/ILM0C70KZQ==",
             "dev": true,
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/core": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.0.tgz",
-            "integrity": "sha512-97z/ju/Jy1rZmDxybphrBuI+jtJjFVoz7Mr9yUQVVVi+DNZE333uFQeMOqcCIy1x3WYBIbWftUSLmbNXNT7qFQ==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.2.tgz",
+            "integrity": "sha512-n7s51eWdaWZ3vGT2tD4T7J6eJs3QoBXydv7vkUM06Bf1cbVD2Kc2UrkzhiQwobfV7NwOnQXYL7UBJ5VPU+RGoQ==",
             "dev": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
@@ -163,10 +163,10 @@
                 "@babel/generator": "^7.23.0",
                 "@babel/helper-compilation-targets": "^7.22.15",
                 "@babel/helper-module-transforms": "^7.23.0",
-                "@babel/helpers": "^7.23.0",
+                "@babel/helpers": "^7.23.2",
                 "@babel/parser": "^7.23.0",
                 "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.23.0",
+                "@babel/traverse": "^7.23.2",
                 "@babel/types": "^7.23.0",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -278,9 +278,9 @@
             }
         },
         "node_modules/@babel/helper-define-polyfill-provider": {
-            "version": "0.4.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.2.tgz",
-            "integrity": "sha512-k0qnnOqHn5dK9pZpfD5XXZ9SojAITdCKRn2Lp6rnDGzIbaP0rHyMPk/4wsSxVBVz4RfN0q6VpXWP2pDGIoQ7hw==",
+            "version": "0.4.3",
+            "resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.3.tgz",
+            "integrity": "sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-compilation-targets": "^7.22.6",
@@ -503,13 +503,13 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.23.1",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.1.tgz",
-            "integrity": "sha512-chNpneuK18yW5Oxsr+t553UZzzAs3aZnFm4bxhebsNTeshrC95yA7l5yl7GBAG+JG1rF0F7zzD2EixK9mWSDoA==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.2.tgz",
+            "integrity": "sha512-lzchcp8SjTSVe/fPmLwtWVBFC7+Tbn8LGHDVfDp9JGxpAY5opSaEFgt8UQvrnECWOTdji2mOWMz1rOhkHscmGQ==",
             "dev": true,
             "dependencies": {
                 "@babel/template": "^7.22.15",
-                "@babel/traverse": "^7.23.0",
+                "@babel/traverse": "^7.23.2",
                 "@babel/types": "^7.23.0"
             },
             "engines": {
@@ -879,14 +879,14 @@
             }
         },
         "node_modules/@babel/plugin-transform-async-generator-functions": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.22.15.tgz",
-            "integrity": "sha512-jBm1Es25Y+tVoTi5rfd5t1KLmL8ogLKpXszboWOTTtGFGz2RKnQe2yn7HbZ+kb/B8N0FVSGQo874NSlOU1T4+w==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-async-generator-functions/-/plugin-transform-async-generator-functions-7.23.2.tgz",
+            "integrity": "sha512-BBYVGxbDVHfoeXbOwcagAkOQAm9NxoTdMGfTqghu1GrvadSaw6iW3Je6IcL5PNOw8VwjxqBECXy50/iCQSY/lQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-environment-visitor": "^7.22.5",
+                "@babel/helper-environment-visitor": "^7.22.20",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "@babel/helper-remap-async-to-generator": "^7.22.9",
+                "@babel/helper-remap-async-to-generator": "^7.22.20",
                 "@babel/plugin-syntax-async-generators": "^7.8.4"
             },
             "engines": {
@@ -1497,16 +1497,16 @@
             }
         },
         "node_modules/@babel/plugin-transform-runtime": {
-            "version": "7.22.15",
-            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.22.15.tgz",
-            "integrity": "sha512-tEVLhk8NRZSmwQ0DJtxxhTrCht1HVo8VaMzYT4w6lwyKBuHsgoioAUA7/6eT2fRfc5/23fuGdlwIxXhRVgWr4g==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.23.2.tgz",
+            "integrity": "sha512-XOntj6icgzMS58jPVtQpiuF6ZFWxQiJavISGx5KGjRj+3gqZr8+N6Kx+N9BApWzgS+DOjIZfXXj0ZesenOWDyA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-module-imports": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
-                "babel-plugin-polyfill-corejs2": "^0.4.5",
-                "babel-plugin-polyfill-corejs3": "^0.8.3",
-                "babel-plugin-polyfill-regenerator": "^0.5.2",
+                "babel-plugin-polyfill-corejs2": "^0.4.6",
+                "babel-plugin-polyfill-corejs3": "^0.8.5",
+                "babel-plugin-polyfill-regenerator": "^0.5.3",
                 "semver": "^6.3.1"
             },
             "engines": {
@@ -1674,12 +1674,12 @@
             }
         },
         "node_modules/@babel/preset-env": {
-            "version": "7.22.20",
-            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.22.20.tgz",
-            "integrity": "sha512-11MY04gGC4kSzlPHRfvVkNAZhUxOvm7DCJ37hPDnUENwe06npjIRAfInEMTGSb4LZK5ZgDFkv5hw0lGebHeTyg==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.2.tgz",
+            "integrity": "sha512-BW3gsuDD+rvHL2VO2SjAUNTBe5YrjsTiDyqamPDWY723na3/yPQ65X5oQkFVJZ0o50/2d+svm1rkPoJeR1KxVQ==",
             "dev": true,
             "dependencies": {
-                "@babel/compat-data": "^7.22.20",
+                "@babel/compat-data": "^7.23.2",
                 "@babel/helper-compilation-targets": "^7.22.15",
                 "@babel/helper-plugin-utils": "^7.22.5",
                 "@babel/helper-validator-option": "^7.22.15",
@@ -1705,15 +1705,15 @@
                 "@babel/plugin-syntax-top-level-await": "^7.14.5",
                 "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
                 "@babel/plugin-transform-arrow-functions": "^7.22.5",
-                "@babel/plugin-transform-async-generator-functions": "^7.22.15",
+                "@babel/plugin-transform-async-generator-functions": "^7.23.2",
                 "@babel/plugin-transform-async-to-generator": "^7.22.5",
                 "@babel/plugin-transform-block-scoped-functions": "^7.22.5",
-                "@babel/plugin-transform-block-scoping": "^7.22.15",
+                "@babel/plugin-transform-block-scoping": "^7.23.0",
                 "@babel/plugin-transform-class-properties": "^7.22.5",
                 "@babel/plugin-transform-class-static-block": "^7.22.11",
                 "@babel/plugin-transform-classes": "^7.22.15",
                 "@babel/plugin-transform-computed-properties": "^7.22.5",
-                "@babel/plugin-transform-destructuring": "^7.22.15",
+                "@babel/plugin-transform-destructuring": "^7.23.0",
                 "@babel/plugin-transform-dotall-regex": "^7.22.5",
                 "@babel/plugin-transform-duplicate-keys": "^7.22.5",
                 "@babel/plugin-transform-dynamic-import": "^7.22.11",
@@ -1725,9 +1725,9 @@
                 "@babel/plugin-transform-literals": "^7.22.5",
                 "@babel/plugin-transform-logical-assignment-operators": "^7.22.11",
                 "@babel/plugin-transform-member-expression-literals": "^7.22.5",
-                "@babel/plugin-transform-modules-amd": "^7.22.5",
-                "@babel/plugin-transform-modules-commonjs": "^7.22.15",
-                "@babel/plugin-transform-modules-systemjs": "^7.22.11",
+                "@babel/plugin-transform-modules-amd": "^7.23.0",
+                "@babel/plugin-transform-modules-commonjs": "^7.23.0",
+                "@babel/plugin-transform-modules-systemjs": "^7.23.0",
                 "@babel/plugin-transform-modules-umd": "^7.22.5",
                 "@babel/plugin-transform-named-capturing-groups-regex": "^7.22.5",
                 "@babel/plugin-transform-new-target": "^7.22.5",
@@ -1736,7 +1736,7 @@
                 "@babel/plugin-transform-object-rest-spread": "^7.22.15",
                 "@babel/plugin-transform-object-super": "^7.22.5",
                 "@babel/plugin-transform-optional-catch-binding": "^7.22.11",
-                "@babel/plugin-transform-optional-chaining": "^7.22.15",
+                "@babel/plugin-transform-optional-chaining": "^7.23.0",
                 "@babel/plugin-transform-parameters": "^7.22.15",
                 "@babel/plugin-transform-private-methods": "^7.22.5",
                 "@babel/plugin-transform-private-property-in-object": "^7.22.11",
@@ -1753,10 +1753,10 @@
                 "@babel/plugin-transform-unicode-regex": "^7.22.5",
                 "@babel/plugin-transform-unicode-sets-regex": "^7.22.5",
                 "@babel/preset-modules": "0.1.6-no-external-plugins",
-                "@babel/types": "^7.22.19",
-                "babel-plugin-polyfill-corejs2": "^0.4.5",
-                "babel-plugin-polyfill-corejs3": "^0.8.3",
-                "babel-plugin-polyfill-regenerator": "^0.5.2",
+                "@babel/types": "^7.23.0",
+                "babel-plugin-polyfill-corejs2": "^0.4.6",
+                "babel-plugin-polyfill-corejs3": "^0.8.5",
+                "babel-plugin-polyfill-regenerator": "^0.5.3",
                 "core-js-compat": "^3.31.0",
                 "semver": "^6.3.1"
             },
@@ -1782,9 +1782,9 @@
             }
         },
         "node_modules/@babel/preset-typescript": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.0.tgz",
-            "integrity": "sha512-6P6VVa/NM/VlAYj5s2Aq/gdVg8FSENCg3wlZ6Qau9AcPaoF5LbN1nyGlR9DTRIw9PpxI94e+ReydsJHcjwAweg==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.23.2.tgz",
+            "integrity": "sha512-u4UJc1XsS1GhIGteM8rnGiIvf9rJpiVgMEeCnwlLA7WJPC+jcXWJAGxYmeqs5hOZD8BbAfnV5ezBOxQbb4OUxA==",
             "dev": true,
             "dependencies": {
                 "@babel/helper-plugin-utils": "^7.22.5",
@@ -1807,9 +1807,9 @@
             "dev": true
         },
         "node_modules/@babel/runtime": {
-            "version": "7.23.1",
-            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.1.tgz",
-            "integrity": "sha512-hC2v6p8ZSI/W0HUzh3V8C5g+NwSKzKPtJwSpTjwl0o297GP9+ZLQSkdvHz46CM3LqyoXxq+5G9komY+eSqSO0g==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.2.tgz",
+            "integrity": "sha512-mM8eg4yl5D6i3lu2QKPuPH4FArvJ8KhTofbE7jwMUv9KX5mBvwPAqnV3MlyBNqdp9RyRKP6Yck8TrfYrPvX3bg==",
             "dependencies": {
                 "regenerator-runtime": "^0.14.0"
             },
@@ -1832,9 +1832,9 @@
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.23.0",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.0.tgz",
-            "integrity": "sha512-t/QaEvyIoIkwzpiZ7aoSKK8kObQYeF7T2v+dazAYCb8SXtp58zEVkWW7zAnju8FNKNdr4ScAOEDmMItbyOmEYw==",
+            "version": "7.23.2",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.2.tgz",
+            "integrity": "sha512-azpe59SQ48qG6nu2CzcMLbxUudtN+dOM9kDbUqGq3HXUJRlo7i8fvPoxQUzYgLZ4cMVmuZgm8vvBpNeRhd6XSw==",
             "dev": true,
             "dependencies": {
                 "@babel/code-frame": "^7.22.13",
@@ -1919,9 +1919,9 @@
             }
         },
         "node_modules/@eslint-community/regexpp": {
-            "version": "4.9.1",
-            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.9.1.tgz",
-            "integrity": "sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==",
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/@eslint-community/regexpp/-/regexpp-4.10.0.tgz",
+            "integrity": "sha512-Cu96Sd2By9mCNTx2iyKOmq10v22jUVQv0lQnlGNy16oE9589yE+QADPbrMGCkA51cKZSg3Pu/aTJVTGfL/qjUA==",
             "dev": true,
             "engines": {
                 "node": "^12.0.0 || ^14.0.0 || >=16.0.0"
@@ -1996,21 +1996,21 @@
             }
         },
         "node_modules/@eslint/js": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.51.0.tgz",
-            "integrity": "sha512-HxjQ8Qn+4SI3/AFv6sOrDB+g6PpUTDwSJiQqOrnneEk8L71161srI9gjzzZvYVbzHiVg/BvcH95+cK/zfIt4pg==",
+            "version": "8.52.0",
+            "resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.52.0.tgz",
+            "integrity": "sha512-mjZVbpaeMZludF2fsWLD0Z9gCref1Tk4i9+wddjRvpUNqqcndPkBD09N/Mapey0b3jaXbLm2kICwFv2E64QinA==",
             "dev": true,
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
         "node_modules/@humanwhocodes/config-array": {
-            "version": "0.11.11",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.11.tgz",
-            "integrity": "sha512-N2brEuAadi0CcdeMXUkhbZB84eskAc8MEX1By6qEchoVywSgXPIjou4rYsl0V3Hj0ZnuGycGCjdNgockbzeWNA==",
+            "version": "0.11.13",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.13.tgz",
+            "integrity": "sha512-JSBDMiDKSzQVngfRjOdFXgFfklaXI4K9nLF49Auh21lmBWRLIK3+xTErTWD4KU54pb6coM6ESE7Awz/FNU3zgQ==",
             "dev": true,
             "dependencies": {
-                "@humanwhocodes/object-schema": "^1.2.1",
+                "@humanwhocodes/object-schema": "^2.0.1",
                 "debug": "^4.1.1",
                 "minimatch": "^3.0.5"
             },
@@ -2032,9 +2032,9 @@
             }
         },
         "node_modules/@humanwhocodes/object-schema": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz",
-            "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@humanwhocodes/object-schema/-/object-schema-2.0.1.tgz",
+            "integrity": "sha512-dvuCeX5fC9dXgJn9t+X5atfmgQAzUOWqS1254Gh0m6i8wKd10ebXkfNKiRK+1GWi/yTvvLDHpoxLr0xxxeslWw==",
             "dev": true
         },
         "node_modules/@istanbuljs/load-nyc-config": {
@@ -2853,9 +2853,9 @@
             "dev": true
         },
         "node_modules/@jridgewell/trace-mapping": {
-            "version": "0.3.19",
-            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.19.tgz",
-            "integrity": "sha512-kf37QtfW+Hwx/buWGMPcR60iF9ziHa6r/CZJIHbmcm4+0qrXiVdxegAH0F6yddEVQ7zdkjcGCgCzUu+BcbhQxw==",
+            "version": "0.3.20",
+            "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.20.tgz",
+            "integrity": "sha512-R8LcPeWZol2zR8mmH3JeKQ6QRCFb7XgUhV9ZlGhHLGyg4wpPiPZNQOOWhFZhxKw8u//yTbNGI42Bx/3paXEQ+Q==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/resolve-uri": "^3.1.0",
@@ -3347,9 +3347,9 @@
             "dev": true
         },
         "node_modules/@types/babel__core": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.2.tgz",
-            "integrity": "sha512-pNpr1T1xLUc2l3xJKuPtsEky3ybxN3m4fJkknfIpTCTfIZCDW57oAg+EfCgIIp2rvCe0Wn++/FfodDS4YXxBwA==",
+            "version": "7.20.3",
+            "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.3.tgz",
+            "integrity": "sha512-54fjTSeSHwfan8AyHWrKbfBWiEUrNTZsUwPTDSNaaP1QDQIZbeNUg3a59E9D+375MzUw/x1vx2/0F5LBz+AeYA==",
             "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.20.7",
@@ -3360,18 +3360,18 @@
             }
         },
         "node_modules/@types/babel__generator": {
-            "version": "7.6.5",
-            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.5.tgz",
-            "integrity": "sha512-h9yIuWbJKdOPLJTbmSpPzkF67e659PbQDba7ifWm5BJ8xTv+sDmS7rFmywkWOvXedGTivCdeGSIIX8WLcRTz8w==",
+            "version": "7.6.6",
+            "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.6.tgz",
+            "integrity": "sha512-66BXMKb/sUWbMdBNdMvajU7i/44RkrA3z/Yt1c7R5xejt8qh84iU54yUWCtm0QwGJlDcf/gg4zd/x4mpLAlb/w==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.0.0"
             }
         },
         "node_modules/@types/babel__template": {
-            "version": "7.4.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.2.tgz",
-            "integrity": "sha512-/AVzPICMhMOMYoSx9MoKpGDKdBRsIXMNByh1PXSZoa+v6ZoLa8xxtsT/uLQ/NJm0XVAWl/BvId4MlDeXJaeIZQ==",
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.3.tgz",
+            "integrity": "sha512-ciwyCLeuRfxboZ4isgdNZi/tkt06m8Tw6uGbBSBgWrnnZGNXiEyM27xc/PjXGQLqlZ6ylbgHMnm7ccF9tCkOeQ==",
             "dev": true,
             "dependencies": {
                 "@babel/parser": "^7.1.0",
@@ -3379,18 +3379,18 @@
             }
         },
         "node_modules/@types/babel__traverse": {
-            "version": "7.20.2",
-            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.2.tgz",
-            "integrity": "sha512-ojlGK1Hsfce93J0+kn3H5R73elidKUaZonirN33GSmgTUMpzI/MIFfSpF3haANe3G1bEBS9/9/QEqwTzwqFsKw==",
+            "version": "7.20.3",
+            "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.20.3.tgz",
+            "integrity": "sha512-Lsh766rGEFbaxMIDH7Qa+Yha8cMVI3qAK6CHt3OR0YfxOIn5Z54iHiyDRycHrBqeIiqGa20Kpsv1cavfBKkRSw==",
             "dev": true,
             "dependencies": {
                 "@babel/types": "^7.20.7"
             }
         },
         "node_modules/@types/body-parser": {
-            "version": "1.19.3",
-            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.3.tgz",
-            "integrity": "sha512-oyl4jvAfTGX9Bt6Or4H9ni1Z447/tQuxnZsytsCaExKlmJiU8sFgnIBRzJUpKwB5eWn9HuBYlUlVA74q/yN0eQ==",
+            "version": "1.19.4",
+            "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.4.tgz",
+            "integrity": "sha512-N7UDG0/xiPQa2D/XrVJXjkWbpqHCd2sBaB32ggRF2l83RhPfamgKGF8gwwqyksS95qUS5ZYF9aF+lLPRlwI2UA==",
             "dev": true,
             "dependencies": {
                 "@types/connect": "*",
@@ -3398,36 +3398,36 @@
             }
         },
         "node_modules/@types/bonjour": {
-            "version": "3.5.11",
-            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.11.tgz",
-            "integrity": "sha512-isGhjmBtLIxdHBDl2xGwUzEM8AOyOvWsADWq7rqirdi/ZQoHnLWErHvsThcEzTX8juDRiZtzp2Qkv5bgNh6mAg==",
+            "version": "3.5.12",
+            "resolved": "https://registry.npmjs.org/@types/bonjour/-/bonjour-3.5.12.tgz",
+            "integrity": "sha512-ky0kWSqXVxSqgqJvPIkgFkcn4C8MnRog308Ou8xBBIVo39OmUFy+jqNe0nPwLCDFxUpmT9EvT91YzOJgkDRcFg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/bootstrap": {
-            "version": "5.2.7",
-            "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.7.tgz",
-            "integrity": "sha512-vWs0HzobIB8Af2F0B1GXpaVLSVn1NWULDYgTIWp08Et/r2B3aAwwhFBeOs/rRFWJA38EZTXkWP3tepIjpQkpLg==",
+            "version": "5.2.8",
+            "resolved": "https://registry.npmjs.org/@types/bootstrap/-/bootstrap-5.2.8.tgz",
+            "integrity": "sha512-14do+aWZPc1w3G+YevSsy8eas1XEPhTOUNBhQX/r12YKn7ySssATJusBQ/HCQAd2nq54U8vvrftHSb1YpeJUXg==",
             "dev": true,
             "dependencies": {
                 "@popperjs/core": "^2.9.2"
             }
         },
         "node_modules/@types/connect": {
-            "version": "3.4.36",
-            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
-            "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
+            "version": "3.4.37",
+            "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.37.tgz",
+            "integrity": "sha512-zBUSRqkfZ59OcwXon4HVxhx5oWCJmc0OtBTK05M+p0dYjgN6iTwIL2T/WbsQZrEsdnwaF9cWQ+azOnpPvIqY3Q==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/connect-history-api-fallback": {
-            "version": "1.5.1",
-            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.1.tgz",
-            "integrity": "sha512-iaQslNbARe8fctL5Lk+DsmgWOM83lM+7FzP0eQUJs1jd3kBE8NWqBTIT2S8SqQOJjxvt2eyIjpOuYeRXq2AdMw==",
+            "version": "1.5.2",
+            "resolved": "https://registry.npmjs.org/@types/connect-history-api-fallback/-/connect-history-api-fallback-1.5.2.tgz",
+            "integrity": "sha512-gX2j9x+NzSh4zOhnRPSdPPmTepS4DfxES0AvIFv3jGv5QyeAJf6u6dY5/BAoAJU9Qq1uTvwOku8SSC2GnCRl6Q==",
             "dev": true,
             "dependencies": {
                 "@types/express-serve-static-core": "*",
@@ -3435,19 +3435,19 @@
             }
         },
         "node_modules/@types/dagre": {
-            "version": "0.7.50",
-            "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.50.tgz",
-            "integrity": "sha512-3HxPUil6GwbcO+q3WxZhM6XMSXYaiXjjzKUDYsGk2tqP5Ko2WpN71I8g1kXLgX5nUkKg00+LlCTuaverWVADGA=="
+            "version": "0.7.51",
+            "resolved": "https://registry.npmjs.org/@types/dagre/-/dagre-0.7.51.tgz",
+            "integrity": "sha512-OJtLXov4mK9wZ4/TkBqUM5OBCpIQvv+sT9FZFnM1Ais5yqHEMnDObGGPYYrQhkLVIKik/bD8o9WWn7YQfPkDlQ=="
         },
         "node_modules/@types/earcut": {
-            "version": "2.1.2",
-            "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.2.tgz",
-            "integrity": "sha512-EU6fwVNP1TGVTkCILfURtzzwJq/ie5LgipELnzCINgm4VdDIkkbB8wnLSe81J77Bbqf4MiO3sJGhWzc6MCp5dQ=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.3.tgz",
+            "integrity": "sha512-pskpibEbm73+7nA9RqxGEnAiALRO92DdoSVxasyjGrqzEndaSDjFG73GCtstMzhdOowZMItVw2fhTdxVrY221w=="
         },
         "node_modules/@types/eslint": {
-            "version": "8.44.3",
-            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.3.tgz",
-            "integrity": "sha512-iM/WfkwAhwmPff3wZuPLYiHX18HI24jU8k1ZSH7P8FHwxTjZ2P6CoX2wnF43oprR+YXJM6UUxATkNvyv/JHd+g==",
+            "version": "8.44.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-8.44.6.tgz",
+            "integrity": "sha512-P6bY56TVmX8y9J87jHNgQh43h6VVU+6H7oN7hgvivV81K2XY8qJZ5vqPy/HdUoVIelii2kChYVzQanlswPWVFw==",
             "dev": true,
             "dependencies": {
                 "@types/estree": "*",
@@ -3455,9 +3455,9 @@
             }
         },
         "node_modules/@types/eslint-scope": {
-            "version": "3.7.5",
-            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.5.tgz",
-            "integrity": "sha512-JNvhIEyxVW6EoMIFIvj93ZOywYFatlpu9deeH6eSx6PE3WHYvHaQtmHmQeNw7aA81bYGBPPQqdtBm6b1SsQMmA==",
+            "version": "3.7.6",
+            "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.6.tgz",
+            "integrity": "sha512-zfM4ipmxVKWdxtDaJ3MP3pBurDXOCoyjvlpE3u6Qzrmw4BPbfm4/ambIeTk/r/J0iq/+2/xp0Fmt+gFvXJY2PQ==",
             "dev": true,
             "dependencies": {
                 "@types/eslint": "*",
@@ -3465,15 +3465,15 @@
             }
         },
         "node_modules/@types/estree": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.2.tgz",
-            "integrity": "sha512-VeiPZ9MMwXjO32/Xu7+OwflfmeoRwkE/qzndw42gGtgJwZopBnzy2gD//NN1+go1mADzkDcqf/KnFRSjTJ8xJA==",
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.4.tgz",
+            "integrity": "sha512-2JwWnHK9H+wUZNorf2Zr6ves96WHoWDJIftkcxPKsS7Djta6Zu519LarhRNljPXkpsZR2ZMwNCPeW7omW07BJw==",
             "dev": true
         },
         "node_modules/@types/express": {
-            "version": "4.17.18",
-            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.18.tgz",
-            "integrity": "sha512-Sxv8BSLLgsBYmcnGdGjjEjqET2U+AKAdCRODmMiq02FgjwuV75Ut85DRpvFjyw/Mk0vgUOliGRU0UUmuuZHByQ==",
+            "version": "4.17.20",
+            "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.20.tgz",
+            "integrity": "sha512-rOaqlkgEvOW495xErXMsmyX3WKBInbhG5eqojXYi3cGUaLoRDlXa5d52fkfWZT963AZ3v2eZ4MbKE6WpDAGVsw==",
             "dev": true,
             "dependencies": {
                 "@types/body-parser": "*",
@@ -3483,9 +3483,9 @@
             }
         },
         "node_modules/@types/express-serve-static-core": {
-            "version": "4.17.37",
-            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.37.tgz",
-            "integrity": "sha512-ZohaCYTgGFcOP7u6aJOhY9uIZQgZ2vxC2yWoArY+FeDXlqeH66ZVBjgvg+RLVAS/DWNq4Ap9ZXu1+SUQiiWYMg==",
+            "version": "4.17.39",
+            "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.39.tgz",
+            "integrity": "sha512-BiEUfAiGCOllomsRAZOiMFP7LAnrifHpt56pc4Z7l9K6ACyN06Ns1JLMBxwkfLOjJRlSf06NwWsT7yzfpaVpyQ==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*",
@@ -3505,57 +3505,57 @@
             }
         },
         "node_modules/@types/graceful-fs": {
-            "version": "4.1.7",
-            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.7.tgz",
-            "integrity": "sha512-MhzcwU8aUygZroVwL2jeYk6JisJrPl/oov/gsgGCue9mkgl9wjGbzReYQClxiUgFDnib9FuHqTndccKeZKxTRw==",
+            "version": "4.1.8",
+            "resolved": "https://registry.npmjs.org/@types/graceful-fs/-/graceful-fs-4.1.8.tgz",
+            "integrity": "sha512-NhRH7YzWq8WiNKVavKPBmtLYZHxNY19Hh+az28O/phfp68CF45pMFud+ZzJ8ewnxnC5smIdF3dqFeiSUQ5I+pw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/http-errors": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.2.tgz",
-            "integrity": "sha512-lPG6KlZs88gef6aD85z3HNkztpj7w2R7HmR3gygjfXCQmsLloWNARFkMuzKiiY8FGdh1XDpgBdrSf4aKDiA7Kg==",
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.3.tgz",
+            "integrity": "sha512-pP0P/9BnCj1OVvQR2lF41EkDG/lWWnDyA203b/4Fmi2eTyORnBtcDoKDwjWQthELrBvWkMOrvSOnZ8OVlW6tXA==",
             "dev": true
         },
         "node_modules/@types/http-proxy": {
-            "version": "1.17.12",
-            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.12.tgz",
-            "integrity": "sha512-kQtujO08dVtQ2wXAuSFfk9ASy3sug4+ogFR8Kd8UgP8PEuc1/G/8yjYRmp//PcDNJEUKOza/MrQu15bouEUCiw==",
+            "version": "1.17.13",
+            "resolved": "https://registry.npmjs.org/@types/http-proxy/-/http-proxy-1.17.13.tgz",
+            "integrity": "sha512-GkhdWcMNiR5QSQRYnJ+/oXzu0+7JJEPC8vkWXK351BkhjraZF+1W13CUYARUvX9+NqIU2n6YHA4iwywsc/M6Sw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/istanbul-lib-coverage": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.4.tgz",
-            "integrity": "sha512-z/QT1XN4K4KYuslS23k62yDIDLwLFkzxOuMplDtObz0+y7VqJCaO2o+SPwHCvLFZh7xazvvoor2tA/hPz9ee7g==",
+            "version": "2.0.5",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
+            "integrity": "sha512-zONci81DZYCZjiLe0r6equvZut0b+dBRPBN5kBDjsONnutYNtJMoWQ9uR2RkL1gLG9NMTzvf+29e5RFfPbeKhQ==",
             "dev": true
         },
         "node_modules/@types/istanbul-lib-report": {
-            "version": "3.0.1",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
-            "integrity": "sha512-gPQuzaPR5h/djlAv2apEG1HVOyj1IUs7GpfMZixU0/0KXT3pm64ylHuMUI1/Akh+sq/iikxg6Z2j+fcMDXaaTQ==",
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.2.tgz",
+            "integrity": "sha512-8toY6FgdltSdONav1XtUHl4LN1yTmLza+EuDazb/fEmRNCwjyqNVIQWs2IfC74IqjHkREs/nQ2FWq5kZU9IC0w==",
             "dev": true,
             "dependencies": {
                 "@types/istanbul-lib-coverage": "*"
             }
         },
         "node_modules/@types/istanbul-reports": {
-            "version": "3.0.2",
-            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.2.tgz",
-            "integrity": "sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==",
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.3.tgz",
+            "integrity": "sha512-1nESsePMBlf0RPRffLZi5ujYh7IH1BWL4y9pr+Bn3cJBdxz+RTP8bUFljLz9HvzhhOSWKdyBZ4DIivdL6rvgZg==",
             "dev": true,
             "dependencies": {
                 "@types/istanbul-lib-report": "*"
             }
         },
         "node_modules/@types/jest": {
-            "version": "29.5.5",
-            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.5.tgz",
-            "integrity": "sha512-ebylz2hnsWR9mYvmBFbXJXr+33UPc4+ZdxyDXh5w0FlPBTfCVN3wPL+kuOiQt3xvrK419v7XWeAs+AeOksafXg==",
+            "version": "29.5.7",
+            "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.7.tgz",
+            "integrity": "sha512-HLyetab6KVPSiF+7pFcUyMeLsx25LDNDemw9mGsJBkai/oouwrjTycocSDYopMEwFhN2Y4s9oPyOCZNofgSt2g==",
             "dev": true,
             "dependencies": {
                 "expect": "^29.0.0",
@@ -3563,32 +3563,32 @@
             }
         },
         "node_modules/@types/jquery": {
-            "version": "3.5.22",
-            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.22.tgz",
-            "integrity": "sha512-ISQFeUK5GwRftLK4PVvKTWEVCxZ2BpaqBz0TWkIq5w4vGojxZP9+XkqgcPjxoqmPeew+HLyWthCBvK7GdF5NYA==",
+            "version": "3.5.25",
+            "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.5.25.tgz",
+            "integrity": "sha512-gykx2c+OZf5nx2tv/5fDQqmvGgTiXshELy5jf9IgXPtVfSBl57IUYByN4osbwMXwJijWGOEYQABzGaFZE79A0Q==",
             "dependencies": {
                 "@types/sizzle": "*"
             }
         },
         "node_modules/@types/jquery-editable-select": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/@types/jquery-editable-select/-/jquery-editable-select-2.2.2.tgz",
-            "integrity": "sha512-4GO+WArptJtdiCNWsb0ivXsIkpzZfYibijos0AAE4EDJXsLIMMbmRE3+2S2XgCbqNU6O8KAdk0rN7209AfDmdQ==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/@types/jquery-editable-select/-/jquery-editable-select-2.2.3.tgz",
+            "integrity": "sha512-64F7Av9IPfBbgIe5tt83xl0HSAqzre4XxrSjJq1GDiJuwa6rNJxhEUPbgkL/reWKCwqC9IjJ77Ecku84KxhuOQ==",
             "dev": true,
             "dependencies": {
                 "@types/jquery": "*"
             }
         },
         "node_modules/@types/json-schema": {
-            "version": "7.0.13",
-            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.13.tgz",
-            "integrity": "sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==",
+            "version": "7.0.14",
+            "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.14.tgz",
+            "integrity": "sha512-U3PUjAudAdJBeC2pgN8uTIKgxrb4nlDF3SF0++EldXQvQBGkpFZMSnwQiIoDU77tv45VgNkl/L4ouD+rEomujw==",
             "dev": true
         },
         "node_modules/@types/mime": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.3.tgz",
-            "integrity": "sha512-Ys+/St+2VF4+xuY6+kDIXGxbNRO0mesVg0bbxEfB97Od1Vjpjx9KD1qxs64Gcb3CWPirk9Xe+PT4YiiHQ9T+eg==",
+            "version": "1.3.4",
+            "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.4.tgz",
+            "integrity": "sha512-1Gjee59G25MrQGk8bsNvC6fxNiRgUlGn2wlhGf95a59DrprnnHk80FIMMFG9XHMdrfsuA119ht06QPDXA1Z7tw==",
             "dev": true
         },
         "node_modules/@types/minimatch": {
@@ -3598,9 +3598,9 @@
             "dev": true
         },
         "node_modules/@types/mocha": {
-            "version": "10.0.2",
-            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.2.tgz",
-            "integrity": "sha512-NaHL0+0lLNhX6d9rs+NSt97WH/gIlRHmszXbQ/8/MV/eVcFNdeJ/GYhrFuUc8K7WuPhRhTSdMkCp8VMzhUq85w==",
+            "version": "10.0.3",
+            "resolved": "https://registry.npmjs.org/@types/mocha/-/mocha-10.0.3.tgz",
+            "integrity": "sha512-RsOPImTriV/OE4A9qKjMtk2MnXiuLLbcO3nCXK+kvq4nr0iMfFgpjaX3MPLb6f7+EL1FGSelYvuJMV6REH+ZPQ==",
             "dev": true
         },
         "node_modules/@types/node": {
@@ -3609,16 +3609,25 @@
             "integrity": "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==",
             "dev": true
         },
+        "node_modules/@types/node-forge": {
+            "version": "1.3.8",
+            "resolved": "https://registry.npmjs.org/@types/node-forge/-/node-forge-1.3.8.tgz",
+            "integrity": "sha512-vGXshY9vim9CJjrpcS5raqSjEfKlJcWy2HNdgUasR66fAnVEYarrf1ULV4nfvpC1nZq/moA9qyqBcu83x+Jlrg==",
+            "dev": true,
+            "dependencies": {
+                "@types/node": "*"
+            }
+        },
         "node_modules/@types/qs": {
-            "version": "6.9.8",
-            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.8.tgz",
-            "integrity": "sha512-u95svzDlTysU5xecFNTgfFG5RUWu1A9P0VzgpcIiGZA9iraHOdSzcxMxQ55DyeRaGCSxQi7LxXDI4rzq/MYfdg==",
+            "version": "6.9.9",
+            "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.9.tgz",
+            "integrity": "sha512-wYLxw35euwqGvTDx6zfY1vokBFnsK0HNrzc6xNHchxfO2hpuRg74GbkEW7e3sSmPvj0TjCDT1VCa6OtHXnubsg==",
             "dev": true
         },
         "node_modules/@types/range-parser": {
-            "version": "1.2.5",
-            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.5.tgz",
-            "integrity": "sha512-xrO9OoVPqFuYyR/loIHjnbvvyRZREYKLjxV4+dY6v3FQR3stQ9ZxIGkaclF7YhI9hfjpuTbu14hZEy94qKLtOA==",
+            "version": "1.2.6",
+            "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.6.tgz",
+            "integrity": "sha512-+0autS93xyXizIYiyL02FCY8N+KkKPhILhcUSA276HxzreZ16kl+cmwvV2qAM/PuCCwPXzOXOWhiPcw20uSFcA==",
             "dev": true
         },
         "node_modules/@types/retry": {
@@ -3628,15 +3637,15 @@
             "dev": true
         },
         "node_modules/@types/semver": {
-            "version": "7.5.3",
-            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.3.tgz",
-            "integrity": "sha512-OxepLK9EuNEIPxWNME+C6WwbRAOOI2o2BaQEGzz5Lu2e4Z5eDnEo+/aVEDMIXywoJitJ7xWd641wrGLZdtwRyw==",
+            "version": "7.5.4",
+            "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.5.4.tgz",
+            "integrity": "sha512-MMzuxN3GdFwskAnb6fz0orFvhfqi752yjaXylr0Rp4oDg5H0Zn1IuyRhDVvYOwAXoJirx2xuS16I3WjxnAIHiQ==",
             "dev": true
         },
         "node_modules/@types/send": {
-            "version": "0.17.2",
-            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.2.tgz",
-            "integrity": "sha512-aAG6yRf6r0wQ29bkS+x97BIs64ZLxeE/ARwyS6wrldMm3C1MdKwCcnnEwMC1slI8wuxJOpiUH9MioC0A0i+GJw==",
+            "version": "0.17.3",
+            "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.3.tgz",
+            "integrity": "sha512-/7fKxvKUoETxjFUsuFlPB9YndePpxxRAOfGC/yJdc9kTjTeP5kRCTzfnE8kPUKCeyiyIZu0YQ76s50hCedI1ug==",
             "dev": true,
             "dependencies": {
                 "@types/mime": "^1",
@@ -3644,18 +3653,18 @@
             }
         },
         "node_modules/@types/serve-index": {
-            "version": "1.9.2",
-            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.2.tgz",
-            "integrity": "sha512-asaEIoc6J+DbBKXtO7p2shWUpKacZOoMBEGBgPG91P8xhO53ohzHWGCs4ScZo5pQMf5ukQzVT9fhX1WzpHihig==",
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/@types/serve-index/-/serve-index-1.9.3.tgz",
+            "integrity": "sha512-4KG+yMEuvDPRrYq5fyVm/I2uqAJSAwZK9VSa+Zf+zUq9/oxSSvy3kkIqyL+jjStv6UCVi8/Aho0NHtB1Fwosrg==",
             "dev": true,
             "dependencies": {
                 "@types/express": "*"
             }
         },
         "node_modules/@types/serve-static": {
-            "version": "1.15.3",
-            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.3.tgz",
-            "integrity": "sha512-yVRvFsEMrv7s0lGhzrggJjNOSmZCdgCjw9xWrPr/kNNLp6FaDfMC1KaYl3TSJ0c58bECwNBMoQrZJ8hA8E1eFg==",
+            "version": "1.15.4",
+            "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.4.tgz",
+            "integrity": "sha512-aqqNfs1XTF0HDrFdlY//+SGUxmdSUbjeRXb5iaZc3x0/vMbYmdw9qvOgHWOyyLFxSSRnUuP5+724zBgfw8/WAw==",
             "dev": true,
             "dependencies": {
                 "@types/http-errors": "*",
@@ -3664,23 +3673,23 @@
             }
         },
         "node_modules/@types/sizzle": {
-            "version": "2.3.4",
-            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.4.tgz",
-            "integrity": "sha512-jA2llq2zNkg8HrALI7DtWzhALcVH0l7i89yhY3iBdOz6cBPeACoFq+fkQrjHA39t1hnSFOboZ7A/AY5MMZSlag=="
+            "version": "2.3.5",
+            "resolved": "https://registry.npmjs.org/@types/sizzle/-/sizzle-2.3.5.tgz",
+            "integrity": "sha512-tAe4Q+OLFOA/AMD+0lq8ovp8t3ysxAOeaScnfNdZpUxaGl51ZMDEITxkvFl1STudQ58mz6gzVGl9VhMKhwRnZQ=="
         },
         "node_modules/@types/sockjs": {
-            "version": "0.3.34",
-            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.34.tgz",
-            "integrity": "sha512-R+n7qBFnm/6jinlteC9DBL5dGiDGjWAvjo4viUanpnc/dG1y7uDoacXPIQ/PQEg1fI912SMHIa014ZjRpvDw4g==",
+            "version": "0.3.35",
+            "resolved": "https://registry.npmjs.org/@types/sockjs/-/sockjs-0.3.35.tgz",
+            "integrity": "sha512-tIF57KB+ZvOBpAQwSaACfEu7htponHXaFzP7RfKYgsOS0NoYnn+9+jzp7bbq4fWerizI3dTB4NfAZoyeQKWJLw==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/stack-utils": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.1.tgz",
-            "integrity": "sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==",
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.2.tgz",
+            "integrity": "sha512-g7CK9nHdwjK2n0ymT2CW698FuWJRIx+RP6embAzZ2Qi8/ilIrA1Imt2LVSeHUzKvpoi7BhmmQcXz95eS0f2JXw==",
             "dev": true
         },
         "node_modules/@types/uuid": {
@@ -3690,33 +3699,33 @@
             "dev": true
         },
         "node_modules/@types/vscode": {
-            "version": "1.83.0",
-            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.83.0.tgz",
-            "integrity": "sha512-3mUtHqLAVz9hegut9au4xehuBrzRE3UJiQMpoEHkNl6XHliihO7eATx2BMHs0odsmmrwjJrlixx/Pte6M3ygDQ==",
+            "version": "1.84.0",
+            "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.84.0.tgz",
+            "integrity": "sha512-lCGOSrhT3cL+foUEqc8G1PVZxoDbiMmxgnUZZTEnHF4mC47eKAUtBGAuMLY6o6Ua8PAuNCoKXbqPmJd1JYnQfg==",
             "dev": true
         },
         "node_modules/@types/ws": {
-            "version": "8.5.6",
-            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.6.tgz",
-            "integrity": "sha512-8B5EO9jLVCy+B58PLHvLDuOD8DRVMgQzq8d55SjLCOn9kqGyqOvy27exVaTio1q1nX5zLu8/6N0n2ThSxOM6tg==",
+            "version": "8.5.8",
+            "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.5.8.tgz",
+            "integrity": "sha512-flUksGIQCnJd6sZ1l5dqCEG/ksaoAg/eUwiLAGTJQcfgvZJKF++Ta4bJA6A5aPSJmsr+xlseHn4KLgVlNnvPTg==",
             "dev": true,
             "dependencies": {
                 "@types/node": "*"
             }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.28",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.28.tgz",
-            "integrity": "sha512-N3e3fkS86hNhtk6BEnc0rj3zcehaxx8QWhCROJkqpl5Zaoi7nAic3jH8q94jVD3zu5LGk+PUB6KAiDmimYOEQw==",
+            "version": "17.0.29",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.29.tgz",
+            "integrity": "sha512-nacjqA3ee9zRF/++a3FUY1suHTFKZeHba2n8WeDw9cCVdmzmHpIxyzOJBcpHvvEmS8E9KqWlSnWHUkOrkhWcvA==",
             "dev": true,
             "dependencies": {
                 "@types/yargs-parser": "*"
             }
         },
         "node_modules/@types/yargs-parser": {
-            "version": "21.0.1",
-            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.1.tgz",
-            "integrity": "sha512-axdPBuLuEJt0c4yI5OZssC19K2Mq1uKdrfZBzuxLvaztgqUtFYZUNw7lETExPYJR9jdEoIg4mb7RQKRQzOkeGQ==",
+            "version": "21.0.2",
+            "resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-21.0.2.tgz",
+            "integrity": "sha512-5qcvofLPbfjmBfKaLfj/+f+Sbd6pN4zl7w7VSVI5uz7m9QZTuB2aZAa2uo1wHFBNN2x6g/SoTkXmd8mQnQF2Cw==",
             "dev": true
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4006,26 +4015,32 @@
                 "url": "https://opencollective.com/typescript-eslint"
             }
         },
+        "node_modules/@ungap/structured-clone": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.2.0.tgz",
+            "integrity": "sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==",
+            "dev": true
+        },
         "node_modules/@vscode/debugadapter": {
-            "version": "1.63.0",
-            "resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.63.0.tgz",
-            "integrity": "sha512-d2eAnYCZkKJ0C28gT93KPi5YXFav8VyagcxkJ94LZ8qqgJ27+2ct26MOHGYKB8L25ZdDs8A4YmyJO32J0afhNQ==",
+            "version": "1.64.0",
+            "resolved": "https://registry.npmjs.org/@vscode/debugadapter/-/debugadapter-1.64.0.tgz",
+            "integrity": "sha512-XygE985qmNCzJExDnam4bErK6FG9Ck8S5TRPDNESwkt7i3OXqw5a3vYb7Dteyhz9YMEf7hwhFoT46Mjc45nJUg==",
             "dependencies": {
-                "@vscode/debugprotocol": "1.63.0"
+                "@vscode/debugprotocol": "1.64.0"
             },
             "engines": {
                 "node": ">=14"
             }
         },
         "node_modules/@vscode/debugprotocol": {
-            "version": "1.63.0",
-            "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.63.0.tgz",
-            "integrity": "sha512-7gewwv69pA7gcJUhtJsru5YN7E1AwwnlBrF5mJY4R/NGInOUqOYOWHlqQwG+4AXn0nXWbcn26MHgaGI9Q26SqA=="
+            "version": "1.64.0",
+            "resolved": "https://registry.npmjs.org/@vscode/debugprotocol/-/debugprotocol-1.64.0.tgz",
+            "integrity": "sha512-Zhf3KvB+J04M4HPE2yCvEILGVtPixXUQMLBvx4QcAtjhc5lnwlZbbt80LCsZO2B+2BH8RMgVXk3QQ5DEzEne2Q=="
         },
         "node_modules/@vscode/test-electron": {
-            "version": "2.3.5",
-            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.5.tgz",
-            "integrity": "sha512-lAW7nQ0HuPqJnGJrtCzEKZCICtRizeP6qNanyCrjmdCOAAWjX3ixiG8RVPwqsYPQBWLPgYuE12qQlwXsOR/2fQ==",
+            "version": "2.3.6",
+            "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.3.6.tgz",
+            "integrity": "sha512-M31xGH0RgqNU6CZ4/9g39oUMJ99nLzfjA+4UbtIQ6TcXQ6+2qkjOOxedmPBDDCg26/3Al5ubjY80hIoaMwKYSw==",
             "dev": true,
             "dependencies": {
                 "http-proxy-agent": "^4.0.1",
@@ -4283,9 +4298,9 @@
             }
         },
         "node_modules/acorn": {
-            "version": "8.10.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-            "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+            "version": "8.11.2",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.2.tgz",
+            "integrity": "sha512-nc0Axzp/0FILLEVsm4fNwLCwMttvhEI263QtVPQcbpfZZ3ts0hLsZGOpE6czNlid7CJ9MlyH8reXkpsf3YUY4w==",
             "dev": true,
             "bin": {
                 "acorn": "bin/acorn"
@@ -4313,9 +4328,9 @@
             }
         },
         "node_modules/acorn-walk": {
-            "version": "8.2.0",
-            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-            "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+            "version": "8.3.0",
+            "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.0.tgz",
+            "integrity": "sha512-FS7hV565M5l1R08MXqo8odwMTB02C2UqzB17RVgu9EyuYFBqJZ3/ZY97sQD5FewVu1UyDFc1yztUDrAwT0EypA==",
             "dev": true,
             "engines": {
                 "node": ">=0.4.0"
@@ -4818,13 +4833,13 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs2": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.5.tgz",
-            "integrity": "sha512-19hwUH5FKl49JEsvyTcoHakh6BE0wgXLLptIyKZ3PijHc/Ci521wygORCUCCred+E/twuqRyAkE02BAWPmsHOg==",
+            "version": "0.4.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.6.tgz",
+            "integrity": "sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==",
             "dev": true,
             "dependencies": {
                 "@babel/compat-data": "^7.22.6",
-                "@babel/helper-define-polyfill-provider": "^0.4.2",
+                "@babel/helper-define-polyfill-provider": "^0.4.3",
                 "semver": "^6.3.1"
             },
             "peerDependencies": {
@@ -4832,25 +4847,25 @@
             }
         },
         "node_modules/babel-plugin-polyfill-corejs3": {
-            "version": "0.8.4",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.4.tgz",
-            "integrity": "sha512-9l//BZZsPR+5XjyJMPtZSK4jv0BsTO1zDac2GC6ygx9WLGlcsnRd1Co0B2zT5fF5Ic6BZy+9m3HNZ3QcOeDKfg==",
+            "version": "0.8.6",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.6.tgz",
+            "integrity": "sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.4.2",
-                "core-js-compat": "^3.32.2"
+                "@babel/helper-define-polyfill-provider": "^0.4.3",
+                "core-js-compat": "^3.33.1"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
             }
         },
         "node_modules/babel-plugin-polyfill-regenerator": {
-            "version": "0.5.2",
-            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.2.tgz",
-            "integrity": "sha512-tAlOptU0Xj34V1Y2PNTL4Y0FOJMDB6bZmoW39FeCQIhigGLkqu3Fj6uiXpxIf6Ij274ENdYx64y6Au+ZKlb1IA==",
+            "version": "0.5.3",
+            "resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.3.tgz",
+            "integrity": "sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==",
             "dev": true,
             "dependencies": {
-                "@babel/helper-define-polyfill-provider": "^0.4.2"
+                "@babel/helper-define-polyfill-provider": "^0.4.3"
             },
             "peerDependencies": {
                 "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -5280,12 +5295,13 @@
             }
         },
         "node_modules/call-bind": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.2.tgz",
-            "integrity": "sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==",
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
+            "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "get-intrinsic": "^1.0.2"
+                "function-bind": "^1.1.2",
+                "get-intrinsic": "^1.2.1",
+                "set-function-length": "^1.1.1"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -5310,9 +5326,9 @@
             }
         },
         "node_modules/caniuse-lite": {
-            "version": "1.0.30001547",
-            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001547.tgz",
-            "integrity": "sha512-W7CrtIModMAxobGhz8iXmDfuJiiKg1WADMO/9x7/CLNin5cpSbuBjooyoIUVB5eyCc36QuTVlkVa1iB2S5+/eA==",
+            "version": "1.0.30001559",
+            "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001559.tgz",
+            "integrity": "sha512-cPiMKZgqgkg5LY3/ntGeLFUpi6tzddBNS58A4tnTgQw1zON7u2sZMU7SzOeVH4tj20++9ggL+V6FDOFMTaFFYA==",
             "dev": true,
             "funding": [
                 {
@@ -5722,9 +5738,9 @@
             "hasInstallScript": true
         },
         "node_modules/core-js-compat": {
-            "version": "3.33.0",
-            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.0.tgz",
-            "integrity": "sha512-0w4LcLXsVEuNkIqwjjf9rjCoPhK8uqA4tMRh4Ge26vfLtUutshn+aRJU21I9LCJlh2QQHfisNToLjw1XEJLTWw==",
+            "version": "3.33.2",
+            "resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.2.tgz",
+            "integrity": "sha512-axfo+wxFVxnqf8RvxTzoAlzW4gRoacrHeoFlc9n0x50+7BEyZL/Rt3hicaED1/CEd7I6tPCPVUYcJwCMO5XUYw==",
             "dev": true,
             "dependencies": {
                 "browserslist": "^4.22.1"
@@ -6051,9 +6067,9 @@
             }
         },
         "node_modules/define-data-property": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.0.tgz",
-            "integrity": "sha512-UzGwzcjyv3OtAvolTj1GoyNYzfFR+iqbGjcnBEENZVCpM4/Ng1yhGNvS3lR/xDS74Tb2wGG9WzNSNIOS9UVb2g==",
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
+            "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
             "dependencies": {
                 "get-intrinsic": "^1.2.1",
                 "gopd": "^1.0.1",
@@ -6194,9 +6210,9 @@
             "dev": true
         },
         "node_modules/electron-to-chromium": {
-            "version": "1.4.548",
-            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.548.tgz",
-            "integrity": "sha512-R77KD6mXv37DOyKLN/eW1rGS61N6yHOfapNSX9w+y9DdPG83l9Gkuv7qkCFZ4Ta4JPhrjgQfYbv4Y3TnM1Hi2Q==",
+            "version": "1.4.575",
+            "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.575.tgz",
+            "integrity": "sha512-kY2BGyvgAHiX899oF6xLXSIf99bAvvdPhDoJwG77nxCSyWYuRH6e9a9a3gpXBvCs6lj4dQZJkfnW2hdKWHEISg==",
             "dev": true
         },
         "node_modules/emittery": {
@@ -6249,9 +6265,9 @@
             }
         },
         "node_modules/envinfo": {
-            "version": "7.10.0",
-            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.10.0.tgz",
-            "integrity": "sha512-ZtUjZO6l5mwTHvc1L9+1q5p/R3wTopcfqMW8r5t8SJSKqeVI/LtajORwRFEKpEFuekjD0VBjwu1HMxL4UalIRw==",
+            "version": "7.11.0",
+            "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.11.0.tgz",
+            "integrity": "sha512-G9/6xF1FPbIw0TtalAMaVPpiq2aDEuKLXM314jPVAO9r2fo2a4BLqMNkmRS7O/xPPZ+COAhGIz3ETvHEV3eUcg==",
             "dev": true,
             "bin": {
                 "envinfo": "dist/cli.js"
@@ -6305,18 +6321,19 @@
             }
         },
         "node_modules/eslint": {
-            "version": "8.51.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.51.0.tgz",
-            "integrity": "sha512-2WuxRZBrlwnXi+/vFSJyjMqrNjtJqiasMzehF0shoLaW7DzS3/9Yvrmq5JiT66+pNjiX4UBnLDiKHcWAr/OInA==",
+            "version": "8.52.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.52.0.tgz",
+            "integrity": "sha512-zh/JHnaixqHZsolRB/w9/02akBk9EPrOs9JwcTP2ek7yL5bVvXuRariiaAjjoJ5DvuwQ1WAE/HsMz+w17YgBCg==",
             "dev": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
                 "@eslint/eslintrc": "^2.1.2",
-                "@eslint/js": "8.51.0",
-                "@humanwhocodes/config-array": "^0.11.11",
+                "@eslint/js": "8.52.0",
+                "@humanwhocodes/config-array": "^0.11.13",
                 "@humanwhocodes/module-importer": "^1.0.1",
                 "@nodelib/fs.walk": "^1.2.8",
+                "@ungap/structured-clone": "^1.2.0",
                 "ajv": "^6.12.4",
                 "chalk": "^4.0.0",
                 "cross-spawn": "^7.0.2",
@@ -7123,9 +7140,9 @@
             }
         },
         "node_modules/fraction.js": {
-            "version": "4.3.6",
-            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.6.tgz",
-            "integrity": "sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==",
+            "version": "4.3.7",
+            "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
+            "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
             "dev": true,
             "engines": {
                 "node": "*"
@@ -7190,9 +7207,12 @@
             }
         },
         "node_modules/function-bind": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+            "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+            "funding": {
+                "url": "https://github.com/sponsors/ljharb"
+            }
         },
         "node_modules/gensync": {
             "version": "1.0.0-beta.2",
@@ -7213,14 +7233,14 @@
             }
         },
         "node_modules/get-intrinsic": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.1.tgz",
-            "integrity": "sha512-2DcsyfABl+gVHEfCOaTrWgyt+tb6MSEGmKq+kI5HwLbIYgjgmMcV8KQ41uaKz1xxUcn9tJtgFbQUEVcEbd0FYw==",
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
+            "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
             "dependencies": {
-                "function-bind": "^1.1.1",
-                "has": "^1.0.3",
+                "function-bind": "^1.1.2",
                 "has-proto": "^1.0.1",
-                "has-symbols": "^1.0.3"
+                "has-symbols": "^1.0.3",
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7379,14 +7399,6 @@
             "integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
             "dev": true
         },
-        "node_modules/has": {
-            "version": "1.0.4",
-            "resolved": "https://registry.npmjs.org/has/-/has-1.0.4.tgz",
-            "integrity": "sha512-qdSAmqLF6209RFj4VVItywPMbm3vWylknmB3nvNiUIs72xAimcM8nVYxYr7ncvZq5qzk9MKIZR8ijqD/1QuYjQ==",
-            "engines": {
-                "node": ">= 0.4.0"
-            }
-        },
         "node_modules/has-ansi": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
@@ -7418,11 +7430,11 @@
             }
         },
         "node_modules/has-property-descriptors": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.0.tgz",
-            "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
+            "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
             "dependencies": {
-                "get-intrinsic": "^1.1.1"
+                "get-intrinsic": "^1.2.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -7462,6 +7474,17 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/hasown": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
+            "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+            "dependencies": {
+                "function-bind": "^1.1.2"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/he": {
@@ -7846,12 +7869,12 @@
             "integrity": "sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ=="
         },
         "node_modules/is-core-module": {
-            "version": "2.13.0",
-            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.0.tgz",
-            "integrity": "sha512-Z7dk6Qo8pOCp3l4tsX2C5ZVas4V+UxwQodwZhLopL91TX8UyyHEXafPcyoeeWuLrwzHcr3igO78wNLwHJHsMCQ==",
+            "version": "2.13.1",
+            "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.13.1.tgz",
+            "integrity": "sha512-hHrIjvZsftOsvKSn2TRYl63zvxsgE0K+0mYMoH6gD4omR5IWB2KynivBQczo3+wF1cCkjzvptnI9Q0sPU66ilw==",
             "dev": true,
             "dependencies": {
-                "has": "^1.0.3"
+                "hasown": "^2.0.0"
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
@@ -9857,9 +9880,9 @@
             }
         },
         "node_modules/jiti": {
-            "version": "1.20.0",
-            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.20.0.tgz",
-            "integrity": "sha512-3TV69ZbrvV6U5DfQimop50jE9Dl6J8O1ja1dvBbMba/sZ3YBEQqJ2VZRoQPVnhlzjNtU1vaXRZVrVjU4qtm8yA==",
+            "version": "1.21.0",
+            "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.0.tgz",
+            "integrity": "sha512-gFqAIbuKyyso/3G2qhiO2OM6shY6EPP/R0+mkDbyspxKazh8BXDC5FiFsUjlczgdNz/vfra0da2y+aHrusLG/Q==",
             "dev": true,
             "bin": {
                 "jiti": "bin/jiti.js"
@@ -10263,11 +10286,11 @@
             "integrity": "sha512-CzQ3IPeIlHQLn2WLmp6nUBGGjaIlIMeGvTTsn1VrjeGZtw89gJx01VJmhmz6V+zvTIcFL8S+NBdKsj4+LRCVDg=="
         },
         "node_modules/mathjs": {
-            "version": "11.11.1",
-            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.11.1.tgz",
-            "integrity": "sha512-uWrwMrhU31TCqHKmm1yFz0C352njGUVr/I1UnpMOxI/VBTTbCktx/mREUXx5Vyg11xrFdg/F3wnMM7Ql/csVsQ==",
+            "version": "11.12.0",
+            "resolved": "https://registry.npmjs.org/mathjs/-/mathjs-11.12.0.tgz",
+            "integrity": "sha512-UGhVw8rS1AyedyI55DGz9q1qZ0p98kyKPyc9vherBkoueLntPfKtPBh14x+V4cdUWK0NZV2TBwqRFlvadscSuw==",
             "dependencies": {
-                "@babel/runtime": "^7.22.15",
+                "@babel/runtime": "^7.23.2",
                 "complex.js": "^2.1.1",
                 "decimal.js": "^10.4.3",
                 "escape-latex": "^1.2.0",
@@ -10791,9 +10814,9 @@
             }
         },
         "node_modules/object-inspect": {
-            "version": "1.12.3",
-            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
-            "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
+            "version": "1.13.1",
+            "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
+            "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
@@ -11729,9 +11752,9 @@
             }
         },
         "node_modules/punycode": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
-            "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
             "dev": true,
             "engines": {
                 "node": ">=6"
@@ -11969,9 +11992,9 @@
             "dev": true
         },
         "node_modules/resolve": {
-            "version": "1.22.6",
-            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.6.tgz",
-            "integrity": "sha512-njhxM7mV12JfufShqGy3Rz8j11RPdLy4xi15UurGJeoHLfJpVXKdh3ueuOqbYUcDZnffr6X739JBo5LzyahEsw==",
+            "version": "1.22.8",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.8.tgz",
+            "integrity": "sha512-oKWePCxqpd6FlLvGV1VU0x7bkPmmCNolxzjMf4NczoDnQcIWrAF+cPtZn5i6n+RfD2d9i0tzpKnG6Yk168yIyw==",
             "dev": true,
             "dependencies": {
                 "is-core-module": "^2.13.0",
@@ -12104,9 +12127,9 @@
             "dev": true
         },
         "node_modules/sass": {
-            "version": "1.69.1",
-            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.1.tgz",
-            "integrity": "sha512-nc969GvTVz38oqKgYYVHM/Iq7Yl33IILy5uqaH2CWSiSUmRCvw+UR7tA3845Sp4BD5ykCUimvrT3k1EjTwpVUA==",
+            "version": "1.69.5",
+            "resolved": "https://registry.npmjs.org/sass/-/sass-1.69.5.tgz",
+            "integrity": "sha512-qg2+UCJibLr2LCVOt3OlPhr/dqVHWOa9XtZf2OjbLs/T4VPSJ00udtgJxH3neXZm+QqX8B+3cU7RaLqp1iVfcQ==",
             "dev": true,
             "dependencies": {
                 "chokidar": ">=3.0.0 <4.0.0",
@@ -12222,11 +12245,12 @@
             "dev": true
         },
         "node_modules/selfsigned": {
-            "version": "2.1.1",
-            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.1.1.tgz",
-            "integrity": "sha512-GSL3aowiF7wa/WtSFwnUrludWFoNhftq8bUkH9pkzjpN2XSPOAYEgg6e0sS9s0rZwgJzJiQRPU18A6clnoW5wQ==",
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/selfsigned/-/selfsigned-2.4.1.tgz",
+            "integrity": "sha512-th5B4L2U+eGLq1TVh7zNRGBapioSORUeymIydxgFpwww9d2qyKvtuPU2jJuHvYAwwqi2Y596QBL3eEqcPEYL8Q==",
             "dev": true,
             "dependencies": {
+                "@types/node-forge": "^1.3.0",
                 "node-forge": "^1"
             },
             "engines": {
@@ -12387,6 +12411,20 @@
             },
             "engines": {
                 "node": ">= 0.8.0"
+            }
+        },
+        "node_modules/set-function-length": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
+            "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+            "dependencies": {
+                "define-data-property": "^1.1.1",
+                "get-intrinsic": "^1.2.1",
+                "gopd": "^1.0.1",
+                "has-property-descriptors": "^1.0.0"
+            },
+            "engines": {
+                "node": ">= 0.4"
             }
         },
         "node_modules/setimmediate": {
@@ -12753,9 +12791,9 @@
             }
         },
         "node_modules/terser": {
-            "version": "5.21.0",
-            "resolved": "https://registry.npmjs.org/terser/-/terser-5.21.0.tgz",
-            "integrity": "sha512-WtnFKrxu9kaoXuiZFSGrcAvvBqAdmKx0SFNmVNYdJamMu9yyN3I/QF0FbH4QcqJQ+y1CJnzxGIKH0cSj+FGYRw==",
+            "version": "5.24.0",
+            "resolved": "https://registry.npmjs.org/terser/-/terser-5.24.0.tgz",
+            "integrity": "sha512-ZpGR4Hy3+wBEzVEnHvstMvqpD/nABNelQn/z2r0fjVWGQsN3bpOLzQlqDxmb4CDZnXq5lpjnQ+mHQLAOpfM5iw==",
             "dev": true,
             "dependencies": {
                 "@jridgewell/source-map": "^0.3.3",
@@ -13371,9 +13409,9 @@
             }
         },
         "node_modules/universalify": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
-            "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
+            "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
             "engines": {
                 "node": ">= 10.0.0"
             }
@@ -13539,9 +13577,9 @@
             }
         },
         "node_modules/webpack": {
-            "version": "5.88.2",
-            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
-            "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+            "version": "5.89.0",
+            "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.89.0.tgz",
+            "integrity": "sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==",
             "dev": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.3",
@@ -13741,12 +13779,13 @@
             }
         },
         "node_modules/webpack-merge": {
-            "version": "5.9.0",
-            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.9.0.tgz",
-            "integrity": "sha512-6NbRQw4+Sy50vYNTw7EyOn41OZItPiXB8GNv3INSoe3PSFaHJEz3SHTrYVaRm2LilNGnFUzh0FAwqPEmU/CwDg==",
+            "version": "5.10.0",
+            "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-5.10.0.tgz",
+            "integrity": "sha512-+4zXKdx7UnO+1jaN4l2lHVD+mFvnlZQP/6ljaJVb4SZiwIKeUnrT5l0gkT8z+n4hKpC+jpOv6O9R+gLtag7pSA==",
             "dev": true,
             "dependencies": {
                 "clone-deep": "^4.0.1",
+                "flat": "^5.0.2",
                 "wildcard": "^2.0.0"
             },
             "engines": {
@@ -13819,12 +13858,12 @@
             }
         },
         "node_modules/which-typed-array": {
-            "version": "1.1.11",
-            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.11.tgz",
-            "integrity": "sha512-qe9UWWpkeG5yzZ0tNYxDmd7vo58HDBc39mZ0xWWpolAGADdFOzkfamWLDxkOWcvHQKVmdTyQdLD4NOfjLWTKew==",
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/which-typed-array/-/which-typed-array-1.1.13.tgz",
+            "integrity": "sha512-P5Nra0qjSncduVPEAr7xhoF5guty49ArDTwzJ/yNuPIbZppyRxFQsRCWrocxIY+CnMVG+qfbU2FmDKyvSGClow==",
             "dependencies": {
                 "available-typed-arrays": "^1.0.5",
-                "call-bind": "^1.0.2",
+                "call-bind": "^1.0.4",
                 "for-each": "^0.3.3",
                 "gopd": "^1.0.1",
                 "has-tostringtag": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "sdfv",
     "displayName": "DaCe SDFG Editor",
     "description": "Transform and optimize data-centric programs with a click of a button",
-    "version": "1.5.9",
+    "version": "1.7.0",
     "engines": {
         "vscode": "^1.75.0"
     },


### PR DESCRIPTION
This PR prepares the October patch to VSCode. For everything in the October patch, see this [milestone](https://github.com/spcl/dace-vscode/milestone/9).
Since it has been a while since the last proper, non-insider release now and most new features have been in insider preview for a while (hence tested), this also prepares the next minor release drafted [here](https://github.com/spcl/dace-vscode/releases/tag/untagged-dd92e2b630f5725db59d).

In this PR:
- [x] Update SDFV
- [x] Update NPM packages to fix vulnerabilities